### PR TITLE
added filter on alert by label

### DIFF
--- a/holmes.py
+++ b/holmes.py
@@ -217,6 +217,7 @@ def alertmanager(
         alertmanager_username=alertmanager_username,
         alertmanager_password=alertmanager_password,
         alertmanager_alertname=alertmanager_alertname,
+        alertmanager_label=alertmanager_label,
         slack_token=slack_token,
         slack_channel=slack_channel,
         custom_toolsets=custom_toolsets,
@@ -233,16 +234,6 @@ def alertmanager(
 
     try:
         issues = source.fetch_issues()
-        if alertmanager_label:
-            label_parts = alertmanager_label.split('=')
-            if len(label_parts) != 2:
-                logging.error(f"The label {alertmanager_label} is of the wrong format use '--alertmanager-label key=value'")
-                return
-            alert_label_key, alert_label_value = label_parts
-            issues = [issue for issue in issues if issue.raw.get("labels", {}).get(alert_label_key, None) == alert_label_value]
-            if not issues:
-                logging.error(f"No valid alerts with the label {alert_label_key} and value {alert_label_value}")
-                return
     except Exception as e:
         logging.error(f"Failed to fetch issues from alertmanager", exc_info=e)
         return

--- a/holmes.py
+++ b/holmes.py
@@ -198,11 +198,8 @@ def alertmanager(
     system_prompt: Optional[str] = typer.Option(
         "builtin://generic_investigation.jinja2", help=system_prompt_help
     ),
-    alert_label_key: Optional[str] = typer.Option(
-        None, help="A key for filtering alerts with specific label key"
-    ),
-    alert_label_value: Optional[str] = typer.Option(
-        None, help="A value for filtering alerts with specific label value"
+    alertmanager_label: Optional[str] = typer.Option(
+        None, help="For filtering alerts with specific labelm must be of format key=value"
     ),
 ):
     """
@@ -236,7 +233,12 @@ def alertmanager(
 
     try:
         issues = source.fetch_issues()
-        if alert_label_key and alert_label_value:
+        if alertmanager_label:
+            label_parts = alertmanager_label.split('=')
+            if len(label_parts) != 2:
+                logging.error(f"The label {alertmanager_label} is of the wrong format use '--alertmanager-label key=value'")
+                return
+            alert_label_key, alert_label_value = label_parts
             issues = [issue for issue in issues if issue.raw and issue.raw.get("labels", {}).get(alert_label_key, None) == alert_label_value]
             if not issues:
                 logging.error(f"No valid alerts with the label {alert_label_key} and value {alert_label_value}")

--- a/holmes.py
+++ b/holmes.py
@@ -198,6 +198,12 @@ def alertmanager(
     system_prompt: Optional[str] = typer.Option(
         "builtin://generic_investigation.jinja2", help=system_prompt_help
     ),
+    alert_label_key: Optional[str] = typer.Option(
+        None, help="A key for filtering alerts with specific label key"
+    ),
+    alert_label_value: Optional[str] = typer.Option(
+        None, help="A value for filtering alerts with specific label value"
+    ),
 ):
     """
     Investigate a Prometheus/Alertmanager alert
@@ -230,6 +236,11 @@ def alertmanager(
 
     try:
         issues = source.fetch_issues()
+        if alert_label_key and alert_label_value:
+            issues = [issue for issue in issues if issue.raw and issue.raw.get("labels", {}).get(alert_label_key, None) == alert_label_value]
+            if not issues:
+                logging.error(f"No valid alerts with the label {alert_label_key} and value {alert_label_value}")
+                return
     except Exception as e:
         logging.error(f"Failed to fetch issues from alertmanager", exc_info=e)
         return

--- a/holmes.py
+++ b/holmes.py
@@ -199,7 +199,7 @@ def alertmanager(
         "builtin://generic_investigation.jinja2", help=system_prompt_help
     ),
     alertmanager_label: Optional[str] = typer.Option(
-        None, help="For filtering alerts with specific labelm must be of format key=value"
+        None, help="For filtering alerts with a specific label must be of format key=value"
     ),
 ):
     """

--- a/holmes.py
+++ b/holmes.py
@@ -239,7 +239,7 @@ def alertmanager(
                 logging.error(f"The label {alertmanager_label} is of the wrong format use '--alertmanager-label key=value'")
                 return
             alert_label_key, alert_label_value = label_parts
-            issues = [issue for issue in issues if issue.raw and issue.raw.get("labels", {}).get(alert_label_key, None) == alert_label_value]
+            issues = [issue for issue in issues if issue.raw.get("labels", {}).get(alert_label_key, None) == alert_label_value]
             if not issues:
                 logging.error(f"No valid alerts with the label {alert_label_key} and value {alert_label_value}")
                 return

--- a/holmes/config.py
+++ b/holmes/config.py
@@ -47,6 +47,7 @@ class Config(RobustaBaseConfig):
     alertmanager_username: Optional[str] = None
     alertmanager_password: Optional[str] = None
     alertmanager_alertname: Optional[str] = None
+    alertmanager_label: Optional[str] = None
 
     jira_url: Optional[str] = None
     jira_username: Optional[str] = None
@@ -255,6 +256,7 @@ class Config(RobustaBaseConfig):
             username=self.alertmanager_username,
             password=self.alertmanager_password,
             alertname=self.alertmanager_alertname,
+            label=self.alertmanager_label,
         )
 
     def create_slack_destination(self):

--- a/holmes/plugins/sources/prometheus/plugin.py
+++ b/holmes/plugins/sources/prometheus/plugin.py
@@ -59,7 +59,7 @@ class AlertManagerSource(SourcePlugin):
         ]
 
         alerts = self.label_filter_issues(alerts)
-        
+
         if self.alertname is not None:
             alertname_filter = re.compile(self.alertname)
             alerts = [a for a in alerts if alertname_filter.match(a.unique_id)]   
@@ -88,11 +88,7 @@ class AlertManagerSource(SourcePlugin):
             raise Exception(f"The label {self.label} is of the wrong format use '--alertmanager-label key=value'")
 
         alert_label_key, alert_label_value = label_parts
-        filtered_issues = [issue for issue in issues if issue.labels.get(alert_label_key, None) == alert_label_value]
-        if not filtered_issues:
-            return []
-
-        return filtered_issues
+        return [issue for issue in issues if issue.labels.get(alert_label_key, None) == alert_label_value]
 
     @staticmethod
     def __format_issue_metadata(alert: PrometheusAlert) -> Optional[str]:


### PR DESCRIPTION
Example run
```
kubectl apply -f https://raw.githubusercontent.com/robusta-dev/kubernetes-demos/main/pending_pods/pending_pod_node_selector.yaml

# wait till alert fires...

poetry run python3 /Users/avirobusta/git/holmesgpt/holmes.py investigate alertmanager --alertmanager-url=http://localhost:9093/ --alert-label-key=pod --alert-label-value=user-profile-import

Configuration file exists at /Users/avirobusta/Library/Preferences/pypoetry, reusing this directory.

Consider moving TOML configuration files to /Users/avirobusta/Library/Application Support/pypoetry, as support for the legacy directory will be removed in an upcoming release.
Analyzing all 1 issues. (Use --alertmanager-alertname to filter.) Press Ctrl+C to stop.
Analyzing issue 1/1: KubePodNotReady...
No runbooks found for this issue. Using default behaviour. (Add runbooks to guide the investigation.)
Running `kubectl describe Pod user-profile-import -n default`                                                                                                                                                                           tools.py:89
────────────────────────────────────────────────────────
AI: Node Affinity Mismatch                                                                                                                                                                                                                             

Resource: Pod user-profile-import                                                                                                                                                                                                                  

Details: Pod user-profile-import is pending because 0/3 nodes match its node affinity/selector criteria.                                                                                                                                           
────────────────────────────────────────────────────────

```
