### PR TITLE
Improve prompt to fix failing tests

### DIFF
--- a/holmes/plugins/prompts/generic_ask.jinja2
+++ b/holmes/plugins/prompts/generic_ask.jinja2
@@ -12,6 +12,12 @@ When investigating a pod that crashed, fetch pods logs with --previous so you se
 
 Do not fetch logs for a pod that crashed with kubectl_logs, use the kubectl_previous_logs tool instead
 
+If asked about problems, do not stop investigating until you are at the final root cause you are able to find. 
+Use the "five whys" methodology to find the root cause.
+For example, if you found a problem in microservice A that is due to an error in microservice B, look at microservice B too and find the error in that.
+If there are incompatibilities between the versions of microservice A and microservice B, state the exact version on each side.
+Do not give an answer like "The pod is pending" as that doesn't state why the pod is pending and how to fix it.
+
 Reply with terse output. Be painfully concise. Leave out "the" and filler words when possible. Be terse but not at the expense of leaving out important data like the root cause and how to fix.
 
 Examples:


### PR DESCRIPTION
# Motivation
Without this change, the ask command occasionally gives "lazy output" like stating that a pod is pending but not investigating why.

# Testing
I ran our benchmarks on this branch to verify that this change fixes the problem and does not cause regressions for other test scenarios. I tested our scenarios with --repeat=5. All tests passed according to the LLM evaluated-results. I then reviewed all the test output manually to verify that there were no undesired consequences of this change in LLM output.

The results look better to me as a result of this change, and I can confirm that is reduces LLM-laziness. (The LLM was not lazy in a single test scenario after this change.)