### PR TITLE
Read default config file from ~/.holmes/config.yaml not current directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # to build it:
 #   docker build -t robusta-ai .
 # to use it:
-#   docker run -it --net=host -v $(pwd)/config.yaml:/app/config.yaml -v ~/.aws:/root/.aws -v ~/.config/gcloud:/root/.config/gcloud -v $HOME/.kube/config:/root/.kube/config robusta-ai ask "what pods are unhealthy and why?"
+#   docker run -it --net=host -v ~/.holmes:/root/.holmes -v ~/.aws:/root/.aws -v ~/.config/gcloud:/root/.config/gcloud -v $HOME/.kube/config:/root/.kube/config robusta-ai ask "what pods are unhealthy and why?"
 FROM python:3.11-slim
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ holmes ask "what issues do I have in my cluster"
 Run the prebuilt Docker container `docker.pkg.dev/genuine-flight-317411/devel/holmes`, with extra flags to mount relevant config files (so that kubectl and other tools can access AWS/GCP resources using your local machine's credentials)
 
 ```bash
-docker run -it --net=host -v $(pwd)/config.yaml:/app/config.yaml -v ~/.aws:/root/.aws -v ~/.config/gcloud:/root/.config/gcloud -v $HOME/.kube/config:/root/.kube/config us-central1-docker.pkg.dev/genuine-flight-317411/devel/holmes ask "what pods are unhealthy and why?"
+docker run -it --net=host -v ~/.holmes:/root/.holmes -v ~/.aws:/root/.aws -v ~/.config/gcloud:/root/.config/gcloud -v $HOME/.kube/config:/root/.kube/config us-central1-docker.pkg.dev/genuine-flight-317411/devel/holmes ask "what pods are unhealthy and why?"
 ```
 </details>
 
@@ -176,7 +176,7 @@ Clone the project from github, and then run:
 ```bash
 cd holmesgpt
 docker build -t holmes .
-docker run -it --net=host -v $(pwd)/config.yaml:/app/config.yaml -v ~/.aws:/root/.aws -v ~/.config/gcloud:/root/.config/gcloud -v $HOME/.kube/config:/root/.kube/config holmes ask "what pods are unhealthy and why?"
+docker run -it --net=host -v -v ~/.holmes:/root/.holmes -v ~/.aws:/root/.aws -v ~/.config/gcloud:/root/.config/gcloud -v $HOME/.kube/config:/root/.kube/config holmes ask "what pods are unhealthy and why?"
 ```
 </details>
 
@@ -275,7 +275,7 @@ holmes ask "Tell me what layers of my pavangudiwada/robusta-ai docker image cons
 
 The more data you give HolmesGPT, the better it will perform. Give it access to more data by adding custom tools.
 
-New tools are loaded using `-t` from [custom toolset files](./examples/custom_toolset.yaml) or by adding them to the `config.yaml` in `custom_toolsets`.
+New tools are loaded using `-t` from [custom toolset files](./examples/custom_toolset.yaml) or by adding them to the `~/.holmes/config.yaml` with the setting `custom_toolsets: ["/path/to/toolset.yaml"]`.
 </details>
 
 <details>
@@ -283,7 +283,7 @@ New tools are loaded using `-t` from [custom toolset files](./examples/custom_to
 
 HolmesGPT can investigate by following runbooks written in plain English. Add your own runbooks to provided the LLM specific instructions.
 
-New runbooks are loaded using `-r` from [custom runbook files](./examples/custom_runbook.yaml) or by adding them to the `config.yaml` in `custom_runbooks`.
+New runbooks are loaded using `-r` from [custom runbook files](./examples/custom_runbook.yaml) or by adding them to the `~/.holmes/config.yaml` with the `custom_runbooks: ["/path/to/runbook.yaml"]`.
 </details>
 
 <details>
@@ -293,10 +293,7 @@ You can customize HolmesGPT's behaviour with command line flags, or you can save
 
 You can view an example config file with all available settings [here](config.example.yaml).
 
-By default, without specifying `--config` the agent will try to read `config.yaml` from the current directory.
-If a setting is specified in both in config file and cli, cli takes precedence.
-
-
+By default, without specifying `--config` the agent will try to read `~/.holmes/config.yaml`. When settings are present in both config file and cli, the cli option takes precedence.
 
 <details>
 <summary>Custom Toolsets</summary>

--- a/holmes/config.py
+++ b/holmes/config.py
@@ -26,6 +26,8 @@ from holmes.plugins.toolsets import (load_builtin_toolsets,
 from holmes.utils.pydantic_utils import RobustaBaseConfig, load_model_from_file
 
 
+DEFAULT_CONFIG_LOCATION = os.path.expanduser("~/.holmes/config.yaml")
+
 class LLMType(StrEnum):
     OPENAI = "openai"
     AZURE = "azure"
@@ -263,13 +265,13 @@ class Config(RobustaBaseConfig):
     @classmethod
     def load_from_file(cls, config_file: Optional[str], **kwargs) -> "Config":
         if config_file is not None:
-            logging.debug("Loading config from file %s", config_file)
+            logging.debug(f"Loading config from file %s", config_file)
             config_from_file = load_model_from_file(cls, config_file)
-        elif os.path.exists("config.yaml"):
-            logging.debug("Loading config from default location config.yaml")
-            config_from_file = load_model_from_file(cls, "config.yaml")
+        elif os.path.exists(DEFAULT_CONFIG_LOCATION):
+            logging.debug(f"Loading config from default location {DEFAULT_CONFIG_LOCATION}")
+            config_from_file = load_model_from_file(cls, DEFAULT_CONFIG_LOCATION)
         else:
-            logging.debug("No config file found, using cli settings only")
+            logging.debug(f"No config file found at {DEFAULT_CONFIG_LOCATION}, using cli settings only")
             config_from_file = None
 
         config_from_cli = cls(**kwargs)

--- a/holmes/main.py
+++ b/holmes/main.py
@@ -66,7 +66,7 @@ opt_model: Optional[str] = typer.Option("gpt-4o", help="Model to use for the LLM
 opt_config_file: Optional[Path] = typer.Option(
     None,
     "--config",
-    help="Path to the config file. Defaults to config.yaml when it exists. Command line arguments take precedence over config file settings",
+    help="Path to the config file. Defaults to ~/.holmes/config.yaml when it exists. Command line arguments take precedence over config file settings",
 )
 opt_custom_toolsets: Optional[List[Path]] = typer.Option(
     [],

--- a/holmes/plugins/destinations/slack/plugin.py
+++ b/holmes/plugins/destinations/slack/plugin.py
@@ -69,11 +69,11 @@ class SlackDestination(DestinationPlugin):
         except SlackApiError as e:
             if e.response.data["error"] == "channel_not_found":
                 logging.error(
-                    f"The channel {self.channel} is not found. Please check the name of the channel in config.yaml"
+                    f"The channel {self.channel} is not found. Please check the value of --slack-channel"
                 )
             elif e.response.data["error"] == "invalid_auth":
                 logging.error(
-                    f"Unable to authenticate using the provided Slack token. Please verify in config.yaml"
+                    f"Unable to authenticate using the provided Slack token. Please verify the setting of --slack-token"
                 )
             else:
                 logging.error(f"Error sending message: {e}. message={text}")

--- a/holmes/utils/pydantic_utils.py
+++ b/holmes/utils/pydantic_utils.py
@@ -35,7 +35,7 @@ def convert_errors(e: ValidationError) -> List[Dict[str, Any]]:
 
 
 def load_model_from_file(
-    model: Type[BaseModel], file_path: str = "config.yaml", yaml_path: str = None
+    model: Type[BaseModel], file_path: str, yaml_path: str = None
 ):
     try:
         contents = benedict(file_path, format="yaml")


### PR DESCRIPTION
This makes holmes behave like other command line tools (e.g. kubectl) and more like users expect. This came up in a recent user feedback call.