### PR TITLE
Fixing alert filter using alertname

### DIFF
--- a/holmes/plugins/sources/prometheus/plugin.py
+++ b/holmes/plugins/sources/prometheus/plugin.py
@@ -93,7 +93,7 @@ class AlertManagerSource(SourcePlugin):
             alerts = self.__fetch_issues_from_api()
 
         if self.alertname_filter is not None:
-            alertname_filter = re.compile(self.alertname)
+            alertname_filter = re.compile(self.alertname_filter)
             alerts = [a for a in alerts if alertname_filter.match(a.unique_id)]
 
         return [


### PR DESCRIPTION
Fixes

```
Traceback (most recent call last):                                                                         
alertmanager                                                                                               
    issues = source.fetch_issues()                                                                         
             ^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                     
line 96, in fetch_issues                                                                                   
    alertname_filter = re.compile(self.alertname)                                                          
                                  ^^^^^^^^^^^^^^                                                           
AttributeError: 'AlertManagerSource' object has no attribute 'alertname'. Did you mean:                    
'username'?     
```