### PR TITLE
Avoid listing tools used during investigations

### DIFF
--- a/holmes/plugins/prompts/generic_investigation.jinja2
+++ b/holmes/plugins/prompts/generic_investigation.jinja2
@@ -33,4 +33,4 @@ Give your answer in the following format:
 # Next Steps
 <what you would do next to troubleshoot this issue, any commands that could be run to fix it, or other ways to solve it (prefer giving precise bash commands when possible)>
 
-<Remove this section and DO NOT list tools and DO NOT add a `# Tools` section>
+<DO NOT list tools used and DO NOT add a `# Tools` section>

--- a/holmes/plugins/prompts/generic_investigation.jinja2
+++ b/holmes/plugins/prompts/generic_investigation.jinja2
@@ -19,7 +19,7 @@ Style Guide:
 * But only quote relevant numbers or metrics that are available. Do not guess.
 * Remove unnecessary words
 
-Give your answer in the following format (there is no need for a section listing all tools that were called but you can mention them in other sections if relevant)
+Give your answer in the following format:
 
 # Alert Explanation
 <1-2 sentences explaining the alert itself - note don't say "The alert indicates a warning event related to a Kubernetes pod doing blah" rather just say "The pod XYZ did blah" because that is what the user actually cares about>
@@ -32,3 +32,6 @@ Give your answer in the following format (there is no need for a section listing
 
 # Next Steps
 <what you would do next to troubleshoot this issue, any commands that could be run to fix it, or other ways to solve it (prefer giving precise bash commands when possible)>
+
+# Tools
+<Remove this section and DO NOT list tools>

--- a/holmes/plugins/prompts/generic_investigation.jinja2
+++ b/holmes/plugins/prompts/generic_investigation.jinja2
@@ -33,5 +33,4 @@ Give your answer in the following format:
 # Next Steps
 <what you would do next to troubleshoot this issue, any commands that could be run to fix it, or other ways to solve it (prefer giving precise bash commands when possible)>
 
-# Tools
-<Remove this section and DO NOT list tools>
+<Remove this section and DO NOT list tools and DO NOT add a `# Tools` section>


### PR DESCRIPTION
This change leads openAI gpt-4o to not return the Tools used directly in the text response.

This has been tested for the following models:
- gpt-4o
- gpt-3.5-turbo
- o1-mini 
- claude-3-opus-20240229
- claude-3-5-sonnet-20241022