### PR TITLE
Only load builtin toolsets when the config is initialised

### DIFF
--- a/holmes/config.py
+++ b/holmes/config.py
@@ -70,6 +70,8 @@ class Config(RobustaBaseConfig):
     custom_runbooks: List[FilePath] = []
     custom_toolsets: List[FilePath] = []
 
+    _builtin_toolsets = load_builtin_toolsets()
+
     @classmethod
     def load_from_env(cls):
         kwargs = {}
@@ -103,7 +105,7 @@ class Config(RobustaBaseConfig):
     def _create_tool_executor(
         self, console: Console, allowed_toolsets: ToolsetPattern
     ) -> ToolExecutor:
-        all_toolsets = load_builtin_toolsets()
+        all_toolsets = list(self._builtin_toolsets)
         for ts_path in self.custom_toolsets:
             all_toolsets.extend(load_toolsets_from_file(ts_path))
 


### PR DESCRIPTION
This PR ensures builtin toolsets are loaded only at initialization time.
This makes sure that the prerequisite checks for each toolset is only run at startup and not for every API call to the server.

If we want this behaviour to also apply to the custom toolsets, then this PR is not enough.