### PR TITLE
Add Pod Affinity Configuration Support to Helm Chart

### DIFF
--- a/helm/holmes/templates/holmes.yaml
+++ b/helm/holmes/templates/holmes.yaml
@@ -24,6 +24,9 @@ spec:
       imagePullSecrets:
       {{- toYaml .Values.imagePullSecrets | nindent 6 }}
       {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{ toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
       containers:
       - name: holmes
         image: "{{ .Values.registry }}/{{ .Values.image }}"

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -20,6 +20,8 @@ enablePostProcessing: false
 postProcessingPrompt: "builtin://generic_post_processing.jinja2"
 openshift: false
 
+affinity: {}
+
 tolerations: []
 
 serviceAccount:


### PR DESCRIPTION
# Add Pod Affinity Configuration Support to Helm Chart

## Description
This PR adds support for Kubernetes pod affinity configurations in the Holmes Helm chart, enabling users to define custom pod scheduling rules through the values file.

## Changes
- Added `affinity` configuration option in `values.yaml` with an empty default object
- Implemented affinity support in the deployment template using Helm's `toYaml` function
- Configured the template to conditionally include affinity settings when provided

## Usage Example
Users can now define pod affinity rules in their values file:

```yaml
affinity:
  nodeAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
      nodeSelectorTerms:
        - matchExpressions:
            - key: nodepool
              operator: In
              values:
                - private
```

## Testing Done
- [ X ] Verified Helm template renders correctly with empty affinity
- [ X ] Verified Helm template renders correctly with sample affinity rules
- [ X ] Tested deployment with actual affinity configurations