### PR TITLE
fix: issue with sections handling messing workload health structured output

### DIFF
--- a/holmes/core/investigation.py
+++ b/holmes/core/investigation.py
@@ -1,8 +1,10 @@
 
+import json
 from typing import Optional
 from rich.console import Console
 from holmes.common.env_vars import HOLMES_POST_PROCESSING_PROMPT
 from holmes.config import Config
+from holmes.core.investigation_structured_output import process_response_into_sections
 from holmes.core.issue import Issue
 from holmes.core.models import InvestigateRequest, InvestigationResult
 from holmes.core.supabase_dal import SupabaseDal
@@ -36,13 +38,15 @@ def investigate_issues(investigate_request: InvestigateRequest, dal: SupabaseDal
         issue,
         prompt=investigate_request.prompt_template,
         post_processing_prompt=HOLMES_POST_PROCESSING_PROMPT,
-        sections=investigate_request.sections,
         instructions=resource_instructions,
         global_instructions=global_instructions
     )
+
+    (text_response, sections) = process_response_into_sections(investigation.result)
+
     return InvestigationResult(
-        analysis=investigation.result,
-        sections=investigation.sections,
+        analysis=text_response,
+        sections=sections,
         tool_calls=investigation.tool_calls or [],
         instructions=investigation.instructions,
     )

--- a/holmes/core/investigation.py
+++ b/holmes/core/investigation.py
@@ -1,7 +1,4 @@
 
-import json
-from typing import Optional
-from rich.console import Console
 from holmes.common.env_vars import HOLMES_POST_PROCESSING_PROMPT
 from holmes.config import Config
 from holmes.core.investigation_structured_output import process_response_into_sections

--- a/holmes/core/investigation_structured_output.py
+++ b/holmes/core/investigation_structured_output.py
@@ -7,8 +7,7 @@ InputSectionsDataType = Dict[str, str]
 
 OutputSectionsDataType = Optional[Dict[str, Union[str, None]]]
 
-class SectionsData(RootModel):
-    root: OutputSectionsDataType
+SectionsData = RootModel[OutputSectionsDataType]
 
 DEFAULT_SECTIONS:InputSectionsDataType = {
     "Alert Explanation": "1-2 sentences explaining the alert itself - note don't say \"The alert indicates a warning event related to a Kubernetes pod doing blah\" rather just say \"The pod XYZ did blah\" because that is what the user actually cares about",

--- a/holmes/core/investigation_structured_output.py
+++ b/holmes/core/investigation_structured_output.py
@@ -48,7 +48,6 @@ def combine_sections(sections: Dict) -> str:
     content = ''
     for section_title, section_content in sections.items():
         if section_content:
-            # content = content + f'\n# {" ".join(section_title.split("_")).title()}\n{section_content}'
             content = content + f'\n# {section_title}\n{section_content}\n'
     return content
 
@@ -59,12 +58,13 @@ def process_response_into_sections(response: Any) -> Tuple[str, OutputSectionsDa
         response = json.dumps(response)
 
     if not isinstance(response, str):
-        # if it's not a string, we make it so
+        # if it's not a string, we make it so as it'll be parsed later
         response = str(response)
 
 
     try:
         parsed_json = json.loads(response)
+        # TODO: force dict values into a string would make this more resilient as SectionsData only accept none/str as values
         sections = SectionsData(root=parsed_json).root
         if sections:
             combined = combine_sections(sections)

--- a/holmes/core/investigation_structured_output.py
+++ b/holmes/core/investigation_structured_output.py
@@ -1,6 +1,16 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple, Union
+import json
 
-DEFAULT_SECTIONS = {
+from pydantic import  RootModel
+
+InputSectionsDataType = Dict[str, str]
+
+OutputSectionsDataType = Optional[Dict[str, Union[str, None]]]
+
+class SectionsData(RootModel):
+    root: OutputSectionsDataType
+
+DEFAULT_SECTIONS:InputSectionsDataType = {
     "Alert Explanation": "1-2 sentences explaining the alert itself - note don't say \"The alert indicates a warning event related to a Kubernetes pod doing blah\" rather just say \"The pod XYZ did blah\" because that is what the user actually cares about",
     "Investigation": "What you checked and found",
     "Conclusions and Possible Root causes": "What conclusions can you reach based on the data you found? what are possible root causes (if you have enough conviction to say) or what uncertainty remains. Don't say root cause but 'possible root causes'. Be clear to distinguish between what you know for certain and what is a possible explanation",
@@ -10,7 +20,7 @@ DEFAULT_SECTIONS = {
     "External links": "Provide links to external sources. Where to look when investigating this issue. For example provide links to relevant runbooks, etc. Add a short sentence describing each link."
 }
 
-def get_output_format_for_investigation(sections: Dict[str, str]) -> Dict[str, Any]:
+def get_output_format_for_investigation(sections: InputSectionsDataType) -> Dict[str, Any]:
 
     properties = {}
     required_fields = []
@@ -34,12 +44,32 @@ def get_output_format_for_investigation(sections: Dict[str, str]) -> Dict[str, A
 
     return output_format
 
-def combine_sections(sections: Any) -> str:
-    if isinstance(sections, dict):
-        content = ''
-        for section_title, section_content in sections.items():
-            if section_content:
-                # content = content + f'\n# {" ".join(section_title.split("_")).title()}\n{section_content}'
-                content = content + f'\n# {section_title}\n{section_content}\n'
-        return content
-    return f"{sections}"
+def combine_sections(sections: Dict) -> str:
+    content = ''
+    for section_title, section_content in sections.items():
+        if section_content:
+            # content = content + f'\n# {" ".join(section_title.split("_")).title()}\n{section_content}'
+            content = content + f'\n# {section_title}\n{section_content}\n'
+    return content
+
+
+def process_response_into_sections(response: Any) -> Tuple[str, OutputSectionsDataType]:
+    if isinstance(response, dict):
+        # No matter if the result is already structured, we want to go through the code below to validate the JSON
+        response = json.dumps(response)
+
+    if not isinstance(response, str):
+        # if it's not a string, we make it so
+        response = str(response)
+
+
+    try:
+        parsed_json = json.loads(response)
+        sections = SectionsData(root=parsed_json).root
+        if sections:
+            combined = combine_sections(sections)
+            return (combined, sections)
+    except Exception:
+        pass
+
+    return (response, None)

--- a/holmes/core/models.py
+++ b/holmes/core/models.py
@@ -1,3 +1,4 @@
+from holmes.core.investigation_structured_output import InputSectionsDataType
 from holmes.core.tool_calling_llm import ToolCallResult
 from typing import Optional, List, Dict, Any, Union
 from pydantic import BaseModel, model_validator
@@ -21,7 +22,7 @@ class InvestigateRequest(BaseModel):
     include_tool_calls: bool = False
     include_tool_call_results: bool = False
     prompt_template: str = "builtin://generic_investigation.jinja2"
-    sections: Optional[Dict[str, str]] = None
+    sections: Optional[InputSectionsDataType] = None
     # TODO in the future
     # response_handler: ...
 

--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -2,7 +2,7 @@ import concurrent.futures
 import json
 import logging
 import textwrap
-from typing import Any, List, Optional, Dict, Type, Union
+from typing import List, Optional, Dict, Type, Union
 from holmes.core.investigation_structured_output import DEFAULT_SECTIONS, InputSectionsDataType, get_output_format_for_investigation
 from holmes.core.performance_timing import PerformanceTiming
 from holmes.utils.tags import format_tags_in_string, parse_messages_tags

--- a/server.py
+++ b/server.py
@@ -148,7 +148,6 @@ def workload_health_check(request: WorkloadHealthRequest):
 
         system_prompt = load_and_render_prompt(request.prompt_template, context={'alerts': workload_alerts})
 
-
         ai = config.create_toolcalling_llm(dal=dal)
 
         structured_output = {"type": "json_object"}


### PR DESCRIPTION
The code to parse the sections for the custom RCA output was in the wrong place, causing it meddle with the structured output from the workload health checks.
This PR moves this code out of the tool_calling_llm.py into the investigation helper