### PR TITLE
log every tool call - even python tools

### DIFF
--- a/holmes/config.py
+++ b/holmes/config.py
@@ -223,7 +223,7 @@ class Config(RobustaBaseConfig):
                 enabled_toolsets.append(ts)
                 logging.info(f"Loaded toolset {ts.name} from {ts.get_path()}")
             elif ts.get_status() == ToolsetStatusEnum.DISABLED:
-                logging.info(f"Disabled toolset: {ts.name} from {ts.get_path()})")
+                logging.info(f"Disabled toolset: {ts.name} from {ts.get_path()}")
             elif ts.get_status() == ToolsetStatusEnum.FAILED:
                 logging.info(
                     f"Failed loading toolset {ts.name} from {ts.get_path()}: ({ts.get_error()})"

--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -263,6 +263,7 @@ class ToolCallingLLM:
 
         tool_response = None
         try:
+            tool.log(tool_params)
             tool_response = tool.invoke(tool_params)
         except Exception as e:
             logging.error(

--- a/holmes/core/tools.py
+++ b/holmes/core/tools.py
@@ -111,6 +111,9 @@ class Tool(ABC, BaseModel):
 
         return result
 
+    def log(self, params: Dict):
+        logging.info(f"Running tool: {self.__class__.__name__} with params {params}")
+
     @abstractmethod
     def invoke(self, params: Dict) -> str:
         return ""
@@ -157,9 +160,11 @@ class YAMLTool(Tool, BaseModel):
         context = {**params}
         return context
 
-    def invoke(self, params) -> str:
+    def log(self, params):
         context = self._build_context(params)
         logging.info(f"Running tool: {self.get_parameterized_one_liner(context)}")
+
+    def invoke(self, params) -> str:
         if self.command is not None:
             raw_output = self.__invoke_command(params)
         else:


### PR DESCRIPTION
We're currently not logging python tool calls, which makes it difficult in the CLI to follow which tools were called. This fix is a little ugly, so feel free to take an alternative approach if you prefer.

I've also removed a typo from one of the log lines.