### PR TITLE
fix: litellm throws NOT_GIVEN error for tool_choice when max_steps is reached

### DIFF
--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -124,7 +124,7 @@ class ToolCallingLLM:
             logging.debug(f"running iteration {i}")
             # on the last step we don't allow tools - we want to force a reply, not a request to run another tool
             tools = NOT_GIVEN if i == max_steps - 1 else tools
-            tool_choice = NOT_GIVEN if tools == NOT_GIVEN else "auto"
+            tool_choice = None if tools == NOT_GIVEN else "auto"
 
             total_tokens = self.llm.count_tokens_for_message(messages)
             max_context_size = self.llm.get_context_window_size()


### PR DESCRIPTION
Fixes the issue below:

```bash
2025-02-26 12:05:05.053 ERROR    Error in /api/chat: Invalid tool choice, tool_choice=NOT_GIVEN. Got=<class 'openai.NotGiven'>. Expecting str, or dict. Please ensure tool_choice follows the OpenAI tool_choice spec
Traceback (most recent call last):
  File "/app/server.py", line 275, in chat
    llm_call = ai.messages_call(messages=messages)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/holmes/core/tool_calling_llm.py", line 105, in messages_call
    return self.call(messages, post_process_prompt, response_format)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/holmes/core/tool_calling_llm.py", line 143, in call
    full_response = self.llm.completion(
                    ^^^^^^^^^^^^^^^^^^^^
  File "/app/holmes/core/llm.py", line 172, in completion
    result = litellm.completion(
             ^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/litellm/utils.py", line 1156, in wrapper
    raise e
  File "/venv/lib/python3.11/site-packages/litellm/utils.py", line 1034, in wrapper
    result = original_function(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/litellm/main.py", line 856, in completion
    tool_choice = validate_chat_completion_tool_choice(tool_choice=tool_choice)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/litellm/utils.py", line 5942, in validate_chat_completion_tool_choice
    raise Exception(
Exception: Invalid tool choice, tool_choice=NOT_GIVEN. Got=<class 'openai.NotGiven'>. Expecting str, or dict. Please ensure tool_choice follows the OpenAI tool_choice spec
```

This can happen when HolmesGPT reaches the max_steps and is forces the LLM to not use tools for the final iteration