### PR TITLE
Allow setting the priority class name in the helm chart

### DIFF
--- a/helm/holmes/templates/holmes.yaml
+++ b/helm/holmes/templates/holmes.yaml
@@ -30,6 +30,9 @@ spec:
       {{- if .Values.affinity }}
       affinity: {{ toYaml .Values.affinity | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       containers:
       - name: holmes
         image: "{{ .Values.registry }}/{{ .Values.image }}"

--- a/helm/holmes/values.yaml
+++ b/helm/holmes/values.yaml
@@ -51,3 +51,5 @@ resources:
 
 additionalVolumes: []
 additionalVolumeMounts: []
+
+priorityClassName: ""


### PR DESCRIPTION
This PR will allow setting the `priorityClassName` for the Deployment in the helm chart.