### PR TITLE
Multi kafka cluster support

### DIFF
--- a/holmes/plugins/toolsets/kafka.py
+++ b/holmes/plugins/toolsets/kafka.py
@@ -186,8 +186,8 @@ class DescribeConsumerGroup(BaseKafkaTool):
     def _invoke(self, params: Dict) -> str:
         group_id = params["group_id"]
         kafka_cluster_name = params["kafka_cluster_name"]
-        client = self.get_kafka_client(kafka_cluster_name)
         try:
+            client = self.get_kafka_client(kafka_cluster_name)
             if client is None:
                 return "No admin_client on toolset. This toolset is misconfigured."
 
@@ -268,8 +268,8 @@ class DescribeTopic(BaseKafkaTool):
     def _invoke(self, params: Dict) -> str:
         topic_name = params["topic_name"]
         kafka_cluster_name = params["kafka_cluster_name"]
-        client = self.get_kafka_client(kafka_cluster_name)
         try:
+            client = self.get_kafka_client(kafka_cluster_name)
             if client is None:
                 return "No admin_client on toolset. This toolset is misconfigured."
             config_future = None
@@ -331,8 +331,8 @@ class FindConsumerGroupsByTopic(BaseKafkaTool):
     def _invoke(self, params: Dict) -> str:
         topic_name = params["topic_name"]
         kafka_cluster_name = params["kafka_cluster_name"]
-        client = self.get_kafka_client(kafka_cluster_name)
         try:
+            client = self.get_kafka_client(kafka_cluster_name)
             if client is None:
                 return "No admin_client on toolset. This toolset is misconfigured."
 

--- a/holmes/plugins/toolsets/kafka.py
+++ b/holmes/plugins/toolsets/kafka.py
@@ -9,6 +9,7 @@ from holmes.core.tools import (
     ToolsetTag,
     CallablePrerequisite,
 )
+from holmes.plugins.toolsets.grafana.common import get_param_or_raise
 from confluent_kafka.admin import (
     AdminClient,
     BrokerMetadata,
@@ -125,7 +126,7 @@ class ListKafkaConsumers(BaseKafkaTool):
 
     def _invoke(self, params: Dict) -> str:
         try:
-            kafka_cluster_name = params["kafka_cluster_name"]
+            kafka_cluster_name = get_param_or_raise(params, "kafka_cluster_name")
             client = self.get_kafka_client(kafka_cluster_name)
             if client is None:
                 return "No admin_client on toolset. This toolset is misconfigured."
@@ -185,8 +186,8 @@ class DescribeConsumerGroup(BaseKafkaTool):
 
     def _invoke(self, params: Dict) -> str:
         group_id = params["group_id"]
-        kafka_cluster_name = params["kafka_cluster_name"]
         try:
+            kafka_cluster_name = get_param_or_raise(params, "kafka_cluster_name")
             client = self.get_kafka_client(kafka_cluster_name)
             if client is None:
                 return "No admin_client on toolset. This toolset is misconfigured."
@@ -224,7 +225,7 @@ class ListTopics(BaseKafkaTool):
 
     def _invoke(self, params: Dict) -> str:
         try:
-            kafka_cluster_name = params["kafka_cluster_name"]
+            kafka_cluster_name = get_param_or_raise(params, "kafka_cluster_name")
             client = self.get_kafka_client(kafka_cluster_name)
             if client is None:
                 return "No admin_client on toolset. This toolset is misconfigured."
@@ -267,8 +268,8 @@ class DescribeTopic(BaseKafkaTool):
 
     def _invoke(self, params: Dict) -> str:
         topic_name = params["topic_name"]
-        kafka_cluster_name = params["kafka_cluster_name"]
         try:
+            kafka_cluster_name = get_param_or_raise(params, "kafka_cluster_name")
             client = self.get_kafka_client(kafka_cluster_name)
             if client is None:
                 return "No admin_client on toolset. This toolset is misconfigured."
@@ -330,8 +331,8 @@ class FindConsumerGroupsByTopic(BaseKafkaTool):
 
     def _invoke(self, params: Dict) -> str:
         topic_name = params["topic_name"]
-        kafka_cluster_name = params["kafka_cluster_name"]
         try:
+            kafka_cluster_name = get_param_or_raise(params, "kafka_cluster_name")
             client = self.get_kafka_client(kafka_cluster_name)
             if client is None:
                 return "No admin_client on toolset. This toolset is misconfigured."


### PR DESCRIPTION
allowed for multi kafka cluster support
example config
```  
kafka/admin:
    config:
      kafka_clusters:
        - name: aks-prod-kafka
          kafka_broker: aks-prod-kafka-1.aks-prod-kafka-brokers.kafka.svc:9095
          kafka_username: kafka-plaintext-user
          kafka_password: ******
          kafka_sasl_mechanism: SCRAM-SHA-512
          kafka_security_protocol: SASL_PLAINTEXT
        - name: gke-stg-kafka
          kafka_broker: gke-stg-kafka.gke-stg-kafka-brokers.kafka.svc:9095
          kafka_username: kafka-plaintext-user
          kafka_password: ****
          kafka_sasl_mechanism: SCRAM-SHA-512
          kafka_security_protocol: SASL_PLAINTEXT
```
<img width="745" alt="Screen Shot 2025-03-10 at 9 00 53" src="https://github.com/user-attachments/assets/cff6babe-04f0-406d-bf3b-cc920b56dca4" />

