### PR TITLE
ROB-1026: improve argocd

### DIFF
--- a/holmes/core/tools.py
+++ b/holmes/core/tools.py
@@ -370,16 +370,21 @@ class Toolset(BaseModel):
     def get_example_config(self) -> Dict[str, Any]:
         return {}
 
-    def _load_llm_instructions(self, jinja_template_file_path: str):
+    def _load_llm_instructions(self, jinja_template: str):
         tool_names = [t.name for t in self.tools]
         self.llm_instructions = load_and_render_prompt(
-            prompt=f"file://{jinja_template_file_path}",
+            prompt=jinja_template,
             context={"tool_names": tool_names, "config": self.config},
         )
 
 
 class YAMLToolset(Toolset):
     tools: List[YAMLTool]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        if self.llm_instructions:
+            self._load_llm_instructions(self.llm_instructions)
 
     def get_example_config(self) -> Dict[str, Any]:
         return {}

--- a/holmes/plugins/toolsets/argocd.yaml
+++ b/holmes/plugins/toolsets/argocd.yaml
@@ -3,6 +3,21 @@ toolsets:
     description: "Set of tools to get argocd metadata like list of apps, repositories, projects, etc."
     docs_url: "https://docs.robusta.dev/master/configuration/holmesgpt/toolsets/argocd.html"
     icon_url: "https://argo-cd.readthedocs.io/en/stable/assets/logo.png"
+    llm_instructions: |
+      You have access to a set of ArgoCD tools for debugging Kubernetes application deployments.
+      If an application's name does not exist in kubernetes, it may exist in argocd: call the tool `argocd_app_list` to find it.
+      These tools help you investigate issues with GitOps-managed applications in your Kubernetes clusters.
+      ALWAYS follow these steps:
+        1. List the applications
+        2. Retrieve the application status and its config
+        3. Retrieve the application's manifests for issues
+        4. Compare the ArgoCD config with the kubernetes status using kubectl tools
+        5. Check for resources mismatch between argocd and kubernetes
+      {% if tool_names|list|length > 0 %}
+      The following commands are available to introspect into ArgoCD: {{ ", ".join(tool_names) }}
+      {% endif %}
+      ALWAYS compare the argocd deployment with kubernetes so that you can suggest better solutions to the user.
+      DO NOT tell the user to check if a resource exists or to update the configuration without being specific, DO checks yourself on behalf of the user and then tell them the solution.
     tags:
       - core
     prerequisites:
@@ -10,17 +25,29 @@ toolsets:
       - env:
           - ARGOCD_AUTH_TOKEN
     tools:
+      - name: "argocd_app_list"
+        description: "List the applications in Argocd"
+        command: "argocd app list"
+
       - name: "argocd_app_get"
         description: "Retrieve information about an existing application, such as its status and configuration"
-        command: "argocd app get {{ app_name }} --show-operation -o yaml"
+        command: "argocd app get {{ app_name }} --show-operation -o wide"
 
       - name: "argocd_app_diff"
         description: "Display the differences between the current state of an application and the desired state specified in its Git repository"
         command: "argocd app diff {{ app_name }}"
 
-      - name: "argocd_app_list"
-        description: "List the applications in Argocd"
-        command: "argocd app list"
+      - name: "argocd_app_manifests"
+        description: "Retrieve manifests for an application"
+        command: "argocd app manifests {{app_name}}"
+
+      - name: "argocd_app_resources"
+        description: "List resources of application"
+        command: "argocd app resources {{app_name}}"
+
+      - name: "argocd_app_manifest_source_revision"
+        description: "Get manifests for a multi-source application at specific revision for specific source"
+        command: "argocd app manifests {{app_name}}{% if revision %} --revision {{ revision }}{% endif %}{% if source %} --source {{ source }}{% endif %}"
 
       - name: "argocd_app_history"
         description: "List the deployment history of an application in ArgoCD"

--- a/holmes/plugins/toolsets/grafana/toolset_grafana_tempo.py
+++ b/holmes/plugins/toolsets/grafana/toolset_grafana_tempo.py
@@ -272,8 +272,7 @@ class GrafanaTempoToolset(BaseGrafanaTempoToolset):
             docs_url="https://grafana.com/oss/tempo/",
             tools=[GetTempoTraces(self), GetTempoTraceById(self), GetTempoTags(self)],
         )
-        self._load_llm_instructions(
-            os.path.abspath(
-                os.path.join(os.path.dirname(__file__), "toolset_grafana_tempo.jinja2")
-            )
+        template_file_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "toolset_grafana_tempo.jinja2")
         )
+        self._load_llm_instructions(jinja_template=f"file://{template_file_path}")

--- a/holmes/plugins/toolsets/opensearch/opensearch_traces.py
+++ b/holmes/plugins/toolsets/opensearch/opensearch_traces.py
@@ -166,13 +166,12 @@ class OpenSearchTracesToolset(Toolset):
                 ToolsetTag.CORE,
             ],
         )
-        self._load_llm_instructions(
-            os.path.abspath(
-                os.path.join(
-                    os.path.dirname(__file__), "opensearch_traces_instructions.jinja2"
-                )
+        template_file_path = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__), "opensearch_traces_instructions.jinja2"
             )
         )
+        self._load_llm_instructions(jinja_template=f"file://{template_file_path}")
 
     def prerequisites_callable(self, config: dict[str, Any]) -> Tuple[bool, str]:
         if not config and not os.environ.get("OPENSEARCH_TRACES_URL", None):

--- a/holmes/plugins/toolsets/prometheus/prometheus.py
+++ b/holmes/plugins/toolsets/prometheus/prometheus.py
@@ -628,13 +628,10 @@ class PrometheusToolset(Toolset):
         self._reload_llm_instructions()
 
     def _reload_llm_instructions(self):
-        self._load_llm_instructions(
-            os.path.abspath(
-                os.path.join(
-                    os.path.dirname(__file__), "prometheus_instructions.jinja2"
-                )
-            )
+        template_file_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "prometheus_instructions.jinja2")
         )
+        self._load_llm_instructions(jinja_template=f"file://{template_file_path}")
 
     def prerequisites_callable(self, config: dict[str, Any]) -> Tuple[bool, str]:
         if not config and not os.environ.get("PROMETHEUS_URL", None):

--- a/holmes/plugins/toolsets/robusta/robusta.py
+++ b/holmes/plugins/toolsets/robusta/robusta.py
@@ -137,11 +137,10 @@ class RobustaToolset(Toolset):
             ],
             is_default=True,
         )
-        self._load_llm_instructions(
-            os.path.abspath(
-                os.path.join(os.path.dirname(__file__), "robusta_instructions.jinja2")
-            )
+        template_file_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "robusta_instructions.jinja2")
         )
+        self._load_llm_instructions(jinja_template=f"file://{template_file_path}")
 
     def get_example_config(self) -> Dict[str, Any]:
         return {}

--- a/tests/llm/fixtures/test_ask_holmes/36_argocd_find_resource/argocd_app_diff.txt
+++ b/tests/llm/fixtures/test_ask_holmes/36_argocd_find_resource/argocd_app_diff.txt
@@ -1,0 +1,25 @@
+{"toolset_name":"argocd/core","tool_name":"argocd_app_diff","match_params":{"app_name":"argocd/demo-app"}}
+Command `argocd app diff argocd/demo-app` failed with return code 1
+stdout:
+
+===== /Service my-demoshop-namespaces/auth-service ======
+0a1,17
+> apiVersion: v1
+> kind: Service
+> metadata:
+>   labels:
+>     app: demoshop
+>     app.kubernetes.io/instance: demo-app
+>     service: auth
+>   name: auth-service
+>   namespace: my-demoshop-namespaces
+> spec:
+>   ports:
+>   - name: http
+>     port: 3006
+>     targetPort: 3006
+>   selector:
+>     app: demoshop
+>     service: auth
+
+stderr:

--- a/tests/llm/fixtures/test_ask_holmes/36_argocd_find_resource/argocd_app_get.txt
+++ b/tests/llm/fixtures/test_ask_holmes/36_argocd_find_resource/argocd_app_get.txt
@@ -1,0 +1,38 @@
+{"toolset_name":"argocd/core","tool_name":"argocd_app_get","match_params":{"app_name":"argocd/demo-app"}}
+stdout:
+Name:               argocd/demo-app
+Project:            default
+Server:             https://kubernetes.default.svc
+Namespace:          
+URL:                https://127.0.0.1:41237/applications/demo-app
+Source:
+- Repo:             https://github.com/Arkhaios-AB/devops-demo
+  Target:           HEAD
+  Path:             .
+SyncWindow:         Sync Allowed
+Sync Policy:        Manual
+Sync Status:        OutOfSync from HEAD (b882d15)
+Health Status:      Missing
+
+Operation:          Sync
+Sync Revision:      b882d1517b40b4a39affad62cff19eb4a14ee43a
+Phase:              Failed
+Start:              2025-04-02 09:15:08 +0200 CEST
+Finished:           2025-04-02 09:15:09 +0200 CEST
+Duration:           1s
+Message:            one or more objects failed to apply, reason: namespaces "my-demoshop-namespaces" not found
+
+GROUP                  KIND            NAMESPACE               NAME                       STATUS     HEALTH   HOOK  MESSAGE
+                       Namespace                               my-demoshop-namespace      Synced                    namespace/my-demoshop-namespace unchanged
+                       Service         my-demoshop-namespace   fraud-service              Synced     Healthy        service/fraud-service unchanged
+                       Service         my-demoshop-namespace   checkout-service           Synced     Healthy        service/checkout-service unchanged
+                       Service         my-demoshop-namespace   backend-service            Synced     Healthy        service/backend-service unchanged
+                       Service         my-demoshop-namespaces  auth-service               OutOfSync  Missing        namespaces "my-demoshop-namespaces" not found
+apps                   Deployment      my-demoshop-namespace   backend-service            Synced     Healthy        deployment.apps/backend-service unchanged
+apps                   Deployment      my-demoshop-namespace   auth-service               Synced     Healthy        deployment.apps/auth-service unchanged
+apps                   Deployment      my-demoshop-namespace   fraud-service              Synced     Healthy        deployment.apps/fraud-service unchanged
+apps                   Deployment      my-demoshop-namespace   checkout-service           Synced     Healthy        deployment.apps/checkout-service unchanged
+monitoring.coreos.com  ServiceMonitor  my-demoshop-namespace   demoshop-services          Synced                    servicemonitor.monitoring.coreos.com/demoshop-services unchanged
+monitoring.coreos.com  PrometheusRule  my-demoshop-namespace   test-nicolas-high-latency  Synced                    prometheusrule.monitoring.coreos.com/test-nicolas-high-latency unchanged
+
+stderr:

--- a/tests/llm/fixtures/test_ask_holmes/36_argocd_find_resource/argocd_app_list.txt
+++ b/tests/llm/fixtures/test_ask_holmes/36_argocd_find_resource/argocd_app_list.txt
@@ -1,0 +1,6 @@
+{"toolset_name":"argocd/core","tool_name":"argocd_app_list","match_params":{}}
+stdout:
+NAME             CLUSTER                         NAMESPACE  PROJECT  STATUS     HEALTH   SYNCPOLICY  CONDITIONS  REPO                                        PATH  TARGET
+argocd/demo-app  https://kubernetes.default.svc             default  OutOfSync  Missing  Manual      <none>      https://github.com/Arkhaios-AB/devops-demo  .     HEAD
+
+stderr:

--- a/tests/llm/fixtures/test_ask_holmes/36_argocd_find_resource/kubectl_describe.txt
+++ b/tests/llm/fixtures/test_ask_holmes/36_argocd_find_resource/kubectl_describe.txt
@@ -1,0 +1,45 @@
+{"toolset_name":"kubernetes/core","tool_name":"kubectl_describe","match_params":{"kind":"deployment","name":"fraud-service","namespace":"my-demoshop-namespace"}}
+stdout:
+Name:                   fraud-service
+Namespace:              my-demoshop-namespace
+CreationTimestamp:      Wed, 02 Apr 2025 07:21:13 +0200
+Labels:                 app=demoshop
+                        app.kubernetes.io/instance=demo-app
+                        service=fraud
+Annotations:            deployment.kubernetes.io/revision: 1
+Selector:               app=demoshop,service=fraud
+Replicas:               1 desired | 1 updated | 1 total | 1 available | 0 unavailable
+StrategyType:           RollingUpdate
+MinReadySeconds:        0
+RollingUpdateStrategy:  25% max unavailable, 25% max surge
+Pod Template:
+  Labels:  app=demoshop
+           service=fraud
+  Containers:
+   fraud:
+    Image:      us-central1-docker.pkg.dev/genuine-flight-317411/devel/shop-app-demo:v1
+    Port:       3005/TCP
+    Host Port:  0/TCP
+    Command:
+      node
+      --require
+      ./dist/telemetry.js
+      ./dist/fraud-service.js
+    Liveness:  http-get http://:3005/fraud/health delay=15s timeout=1s period=20s #success=1 #failure=3
+    Environment:
+      TEMPO_URL:     http://opentelemetry-collector-agent.tt:4318/v1/traces
+      SERVICE_NAME:  fraud-service
+    Mounts:          <none>
+  Volumes:           <none>
+  Node-Selectors:    <none>
+  Tolerations:       <none>
+Conditions:
+  Type           Status  Reason
+  ----           ------  ------
+  Available      True    MinimumReplicasAvailable
+  Progressing    True    NewReplicaSetAvailable
+OldReplicaSets:  <none>
+NewReplicaSet:   fraud-service-54df9b7d75 (1/1 replicas created)
+Events:          <none>
+
+stderr:

--- a/tests/llm/fixtures/test_ask_holmes/36_argocd_find_resource/kubectl_find_resource_deployment.txt
+++ b/tests/llm/fixtures/test_ask_holmes/36_argocd_find_resource/kubectl_find_resource_deployment.txt
@@ -1,0 +1,5 @@
+{"toolset_name":"kubernetes/core","tool_name":"kubectl_find_resource","match_params":{"kind":"deployment","keyword":"demo-app"}}
+Command `kubectl get -A --show-labels -o wide deployment | grep demo-app` failed with return code 1
+stdout:
+
+stderr:

--- a/tests/llm/fixtures/test_ask_holmes/36_argocd_find_resource/kubectl_find_resource_pod.txt
+++ b/tests/llm/fixtures/test_ask_holmes/36_argocd_find_resource/kubectl_find_resource_pod.txt
@@ -1,0 +1,5 @@
+{"toolset_name":"kubernetes/core","tool_name":"kubectl_find_resource","match_params":{"kind":"pod","keyword":"demo-app"}}
+Command `kubectl get -A --show-labels -o wide pod | grep demo-app` failed with return code 1
+stdout:
+
+stderr:

--- a/tests/llm/fixtures/test_ask_holmes/36_argocd_find_resource/kubectl_lineage_children.txt
+++ b/tests/llm/fixtures/test_ask_holmes/36_argocd_find_resource/kubectl_lineage_children.txt
@@ -1,0 +1,10 @@
+{"toolset_name":"kubernetes/kube-lineage-extras","tool_name":"kubectl_lineage_children","match_params":{"kind":"deployment","name":"fraud-service","namespace":"my-demoshop-namespace"}}
+stdout:
+NAME                                                READY   STATUS    AGE
+Deployment/fraud-service                            1/1               3h29m
+└── ReplicaSet/fraud-service-54df9b7d75             1/1               3h29m
+    └── Pod/fraud-service-54df9b7d75-z6m75          1/1     Running   3h29m
+        └── Service/fraud-service                   -                 3h29m
+            └── EndpointSlice/fraud-service-tp2xq   -                 3h29m
+
+stderr:

--- a/tests/llm/fixtures/test_ask_holmes/36_argocd_find_resource/kubectl_logs_all_containers.txt
+++ b/tests/llm/fixtures/test_ask_holmes/36_argocd_find_resource/kubectl_logs_all_containers.txt
@@ -1,0 +1,886 @@
+{"toolset_name":"kubernetes/logs","tool_name":"kubectl_logs_all_containers","match_params":{"pod_name":"fraud-service-54df9b7d75-z6m75","namespace":"my-demoshop-namespace"}}
+stdout:
+{"level":30,"time":1743577959399,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","msg":"Server listening at http://127.0.0.1:3005"}
+Backend server is running on http://localhost:3004
+{"level":30,"time":1743577959399,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","msg":"Server listening at http://10.244.1.13:3005"}
+{"level":30,"time":1743577977213,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":35154},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743577977220,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2","res":{"statusCode":200},"responseTime":6.06429300000309,"msg":"request completed"}
+{"level":30,"time":1743577997210,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39738},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743577997211,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4","res":{"statusCode":200},"responseTime":0.8017209999961779,"msg":"request completed"}
+{"level":30,"time":1743578017213,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":46248},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578017214,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6","res":{"statusCode":200},"responseTime":0.83721900000819,"msg":"request completed"}
+{"level":30,"time":1743578037216,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":34106},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578037218,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9","res":{"statusCode":200},"responseTime":1.1413730000058422,"msg":"request completed"}
+{"level":30,"time":1743578057214,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-b","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60578},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578057215,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-b","res":{"statusCode":200},"responseTime":1.2468099999969127,"msg":"request completed"}
+{"level":30,"time":1743578077215,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-d","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":55696},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578077217,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-d","res":{"statusCode":200},"responseTime":0.8797990000166465,"msg":"request completed"}
+{"level":30,"time":1743578097219,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-g","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":54670},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578097221,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-g","res":{"statusCode":200},"responseTime":0.9178780000074767,"msg":"request completed"}
+{"level":30,"time":1743578117219,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-i","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":46538},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578117220,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-i","res":{"statusCode":200},"responseTime":0.8071010000130627,"msg":"request completed"}
+{"level":30,"time":1743578137221,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-k","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":42444},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578137223,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-k","res":{"statusCode":200},"responseTime":1.590271999972174,"msg":"request completed"}
+{"level":30,"time":1743578157221,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-n","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60118},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578157222,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-n","res":{"statusCode":200},"responseTime":0.909378000011202,"msg":"request completed"}
+{"level":30,"time":1743578177221,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-p","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39538},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578177223,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-p","res":{"statusCode":200},"responseTime":0.7628109999932349,"msg":"request completed"}
+{"level":30,"time":1743578197224,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-r","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":36488},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578197226,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-r","res":{"statusCode":200},"responseTime":1.4861539999837987,"msg":"request completed"}
+{"level":30,"time":1743578217226,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-u","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":42738},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578217227,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-u","res":{"statusCode":200},"responseTime":0.7121330000227317,"msg":"request completed"}
+{"level":30,"time":1743578237224,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-w","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":47914},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578237225,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-w","res":{"statusCode":200},"responseTime":0.43575000000419095,"msg":"request completed"}
+{"level":30,"time":1743578257228,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-y","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":52662},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578257228,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-y","res":{"statusCode":200},"responseTime":0.4479690000298433,"msg":"request completed"}
+{"level":30,"time":1743578277229,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-11","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":59240},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578277230,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-11","res":{"statusCode":200},"responseTime":0.6521340000326745,"msg":"request completed"}
+{"level":30,"time":1743578297230,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-13","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":42366},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578297231,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-13","res":{"statusCode":200},"responseTime":0.7242519999854267,"msg":"request completed"}
+{"level":30,"time":1743578317231,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-15","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":43732},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578317232,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-15","res":{"statusCode":200},"responseTime":0.4083499999833293,"msg":"request completed"}
+{"level":30,"time":1743578337231,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-18","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":38072},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578337232,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-18","res":{"statusCode":200},"responseTime":0.6173149999813177,"msg":"request completed"}
+{"level":30,"time":1743578357231,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1a","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":35146},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578357232,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1a","res":{"statusCode":200},"responseTime":0.6234849999891594,"msg":"request completed"}
+{"level":30,"time":1743578377235,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1c","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":42624},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578377236,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1c","res":{"statusCode":200},"responseTime":0.7679909999715164,"msg":"request completed"}
+{"level":30,"time":1743578397236,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1f","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":46654},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578397238,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1f","res":{"statusCode":200},"responseTime":0.8449590000091121,"msg":"request completed"}
+{"level":30,"time":1743578417235,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1h","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":52832},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578417235,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1h","res":{"statusCode":200},"responseTime":0.6464740000083111,"msg":"request completed"}
+{"level":30,"time":1743578437236,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1j","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60466},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578437237,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1j","res":{"statusCode":200},"responseTime":0.50906800001394,"msg":"request completed"}
+{"level":30,"time":1743578457238,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1m","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":58688},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578457239,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1m","res":{"statusCode":200},"responseTime":0.6317649999982677,"msg":"request completed"}
+{"level":30,"time":1743578477238,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1o","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":44932},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578477238,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1o","res":{"statusCode":200},"responseTime":0.5345770000712946,"msg":"request completed"}
+{"level":30,"time":1743578497241,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1q","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":57494},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578497242,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1q","res":{"statusCode":200},"responseTime":0.7114130000118166,"msg":"request completed"}
+{"level":30,"time":1743578517243,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1t","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":55476},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578517244,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1t","res":{"statusCode":200},"responseTime":0.5858249999582767,"msg":"request completed"}
+{"level":30,"time":1743578537243,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1v","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39610},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578537244,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1v","res":{"statusCode":200},"responseTime":0.8369899999815971,"msg":"request completed"}
+{"level":30,"time":1743578557245,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1x","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39284},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578557246,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-1x","res":{"statusCode":200},"responseTime":0.7487320000072941,"msg":"request completed"}
+{"level":30,"time":1743578577247,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-20","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":49902},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578577248,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-20","res":{"statusCode":200},"responseTime":0.44488900003489107,"msg":"request completed"}
+{"level":30,"time":1743578597247,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-22","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":36602},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578597247,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-22","res":{"statusCode":200},"responseTime":0.4384389999322593,"msg":"request completed"}
+{"level":30,"time":1743578617247,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-24","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":44746},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578617248,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-24","res":{"statusCode":200},"responseTime":0.7294320000801235,"msg":"request completed"}
+{"level":30,"time":1743578637249,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-27","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":46882},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578637250,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-27","res":{"statusCode":200},"responseTime":0.8026100000133738,"msg":"request completed"}
+{"level":30,"time":1743578657249,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-29","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":56552},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578657250,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-29","res":{"statusCode":200},"responseTime":0.6903330000350252,"msg":"request completed"}
+** headers health -> undefined
+{"level":30,"time":1743578677252,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2b","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60074},"msg":"incoming request"}
+{"level":30,"time":1743578677253,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2b","res":{"statusCode":200},"responseTime":0.49033900001086295,"msg":"request completed"}
+** headers health -> undefined
+{"level":30,"time":1743578697253,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2e","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":41514},"msg":"incoming request"}
+{"level":30,"time":1743578697254,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2e","res":{"statusCode":200},"responseTime":0.8922579999780282,"msg":"request completed"}
+{"level":30,"time":1743578717254,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2g","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":35372},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578717255,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2g","res":{"statusCode":200},"responseTime":0.5256380001083016,"msg":"request completed"}
+{"level":30,"time":1743578737254,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2i","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":57600},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578737255,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2i","res":{"statusCode":200},"responseTime":0.7041029999963939,"msg":"request completed"}
+{"level":30,"time":1743578757257,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2l","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":36840},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578757258,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2l","res":{"statusCode":200},"responseTime":0.7675919999601319,"msg":"request completed"}
+{"level":30,"time":1743578777256,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2n","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":43514},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578777257,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2n","res":{"statusCode":200},"responseTime":0.6525439999531955,"msg":"request completed"}
+{"level":30,"time":1743578797259,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2p","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":41874},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578797260,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2p","res":{"statusCode":200},"responseTime":0.7310820000711828,"msg":"request completed"}
+{"level":30,"time":1743578817260,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2s","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":56110},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578817261,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2s","res":{"statusCode":200},"responseTime":0.848450000048615,"msg":"request completed"}
+{"level":30,"time":1743578837260,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2u","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":36986},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578837260,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2u","res":{"statusCode":200},"responseTime":0.6858240000437945,"msg":"request completed"}
+{"level":30,"time":1743578857263,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2w","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":49050},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578857264,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2w","res":{"statusCode":200},"responseTime":0.9100580000085756,"msg":"request completed"}
+{"level":30,"time":1743578877265,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2z","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":51638},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578877266,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-2z","res":{"statusCode":200},"responseTime":0.3991999999852851,"msg":"request completed"}
+{"level":30,"time":1743578897266,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-31","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":59790},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578897266,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-31","res":{"statusCode":200},"responseTime":0.5552669999888167,"msg":"request completed"}
+{"level":30,"time":1743578917267,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-33","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60770},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578917268,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-33","res":{"statusCode":200},"responseTime":0.4339489999692887,"msg":"request completed"}
+{"level":30,"time":1743578937267,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-36","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":38434},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578937269,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-36","res":{"statusCode":200},"responseTime":1.164591999957338,"msg":"request completed"}
+{"level":30,"time":1743578957267,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-38","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":44234},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578957268,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-38","res":{"statusCode":200},"responseTime":0.6994440000271425,"msg":"request completed"}
+{"level":30,"time":1743578977271,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3a","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":55382},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578977271,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3a","res":{"statusCode":200},"responseTime":0.4347190000116825,"msg":"request completed"}
+{"level":30,"time":1743578997271,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3d","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":37962},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743578997272,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3d","res":{"statusCode":200},"responseTime":0.6446440001018345,"msg":"request completed"}
+{"level":30,"time":1743579017273,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3f","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39980},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579017274,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3f","res":{"statusCode":200},"responseTime":0.7554910001344979,"msg":"request completed"}
+{"level":30,"time":1743579037274,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3h","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":35148},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579037274,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3h","res":{"statusCode":200},"responseTime":0.5627859998494387,"msg":"request completed"}
+{"level":30,"time":1743579057274,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3k","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":57648},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579057275,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3k","res":{"statusCode":200},"responseTime":0.5548859999980778,"msg":"request completed"}
+{"level":30,"time":1743579077276,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3m","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":46738},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579077277,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3m","res":{"statusCode":200},"responseTime":0.5078679998405278,"msg":"request completed"}
+{"level":30,"time":1743579097278,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3o","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":50696},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579097279,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3o","res":{"statusCode":200},"responseTime":0.4634689998347312,"msg":"request completed"}
+{"level":30,"time":1743579117279,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3r","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39116},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579117280,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3r","res":{"statusCode":200},"responseTime":0.4496389999985695,"msg":"request completed"}
+{"level":30,"time":1743579137280,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3t","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":35992},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579137281,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3t","res":{"statusCode":200},"responseTime":0.5339969999622554,"msg":"request completed"}
+{"level":30,"time":1743579157280,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3v","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":33114},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579157280,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3v","res":{"statusCode":200},"responseTime":0.5615159999579191,"msg":"request completed"}
+{"level":30,"time":1743579177283,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3y","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":58124},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579177284,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-3y","res":{"statusCode":200},"responseTime":0.49804800003767014,"msg":"request completed"}
+{"level":30,"time":1743579197284,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-40","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60266},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579197284,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-40","res":{"statusCode":200},"responseTime":0.5617760000750422,"msg":"request completed"}
+{"level":30,"time":1743579217285,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-42","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":46174},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579217286,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-42","res":{"statusCode":200},"responseTime":0.4795590001158416,"msg":"request completed"}
+{"level":30,"time":1743579237287,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-45","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":44502},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579237288,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-45","res":{"statusCode":200},"responseTime":0.6240050001069903,"msg":"request completed"}
+{"level":30,"time":1743579257285,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-47","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":33552},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579257286,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-47","res":{"statusCode":200},"responseTime":0.6135050000157207,"msg":"request completed"}
+{"level":30,"time":1743579277287,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-49","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":43430},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579277287,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-49","res":{"statusCode":200},"responseTime":0.4863890002015978,"msg":"request completed"}
+{"level":30,"time":1743579297289,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4c","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":55414},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579297289,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4c","res":{"statusCode":200},"responseTime":0.4017299998085946,"msg":"request completed"}
+{"level":30,"time":1743579317291,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4e","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":49658},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579317292,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4e","res":{"statusCode":200},"responseTime":0.6277750001754612,"msg":"request completed"}
+{"level":30,"time":1743579337292,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4g","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":59470},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579337293,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4g","res":{"statusCode":200},"responseTime":0.8113009999506176,"msg":"request completed"}
+{"level":30,"time":1743579357294,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4j","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":37776},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579357295,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4j","res":{"statusCode":200},"responseTime":0.6207749999593943,"msg":"request completed"}
+{"level":30,"time":1743579377292,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4l","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39148},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579377293,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4l","res":{"statusCode":200},"responseTime":0.4035199999343604,"msg":"request completed"}
+{"level":30,"time":1743579397296,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4n","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":49772},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579397297,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4n","res":{"statusCode":200},"responseTime":0.56796699995175,"msg":"request completed"}
+{"level":30,"time":1743579417298,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4q","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":33662},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579417299,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4q","res":{"statusCode":200},"responseTime":0.6129650000948459,"msg":"request completed"}
+{"level":30,"time":1743579437298,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4s","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":50346},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579437299,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4s","res":{"statusCode":200},"responseTime":0.6576439999043941,"msg":"request completed"}
+{"level":30,"time":1743579457297,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4u","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":37932},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579457298,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4u","res":{"statusCode":200},"responseTime":0.48038800014182925,"msg":"request completed"}
+{"level":30,"time":1743579477301,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4x","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":38476},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579477302,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4x","res":{"statusCode":200},"responseTime":0.46001900010742247,"msg":"request completed"}
+{"level":30,"time":1743579497301,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4z","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":45592},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579497302,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-4z","res":{"statusCode":200},"responseTime":0.6090849998872727,"msg":"request completed"}
+{"level":30,"time":1743579517303,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-51","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":37130},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579517304,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-51","res":{"statusCode":200},"responseTime":0.6563440000172704,"msg":"request completed"}
+{"level":30,"time":1743579537303,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-54","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":49806},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579537304,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-54","res":{"statusCode":200},"responseTime":0.5530560000333935,"msg":"request completed"}
+{"level":30,"time":1743579557303,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-56","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":46270},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579557304,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-56","res":{"statusCode":200},"responseTime":0.686043000081554,"msg":"request completed"}
+{"level":30,"time":1743579577307,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-58","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":51972},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579577308,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-58","res":{"statusCode":200},"responseTime":0.7258920001331717,"msg":"request completed"}
+{"level":30,"time":1743579597307,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5b","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":36138},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579597308,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5b","res":{"statusCode":200},"responseTime":0.655674000037834,"msg":"request completed"}
+{"level":30,"time":1743579617309,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5d","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":51858},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579617310,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5d","res":{"statusCode":200},"responseTime":0.9321569998282939,"msg":"request completed"}
+{"level":30,"time":1743579637310,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5f","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":47958},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579637311,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5f","res":{"statusCode":200},"responseTime":0.43905899999663234,"msg":"request completed"}
+{"level":30,"time":1743579657312,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5i","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":37866},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579657313,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5i","res":{"statusCode":200},"responseTime":0.5880359997972846,"msg":"request completed"}
+{"level":30,"time":1743579677312,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5k","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":46442},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579677313,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5k","res":{"statusCode":200},"responseTime":0.8078110001515597,"msg":"request completed"}
+{"level":30,"time":1743579697312,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5m","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":38496},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579697312,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5m","res":{"statusCode":200},"responseTime":0.614534999942407,"msg":"request completed"}
+{"level":30,"time":1743579717315,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5p","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":41376},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579717316,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5p","res":{"statusCode":200},"responseTime":0.6288139999378473,"msg":"request completed"}
+{"level":30,"time":1743579737313,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5r","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":57070},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579737314,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5r","res":{"statusCode":200},"responseTime":0.703133000060916,"msg":"request completed"}
+{"level":30,"time":1743579757315,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5t","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":41548},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579757316,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5t","res":{"statusCode":200},"responseTime":0.8076410000212491,"msg":"request completed"}
+{"level":30,"time":1743579777317,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5w","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":56858},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579777318,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5w","res":{"statusCode":200},"responseTime":0.6810639998875558,"msg":"request completed"}
+{"level":30,"time":1743579797319,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5y","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":58286},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579797320,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-5y","res":{"statusCode":200},"responseTime":0.7220620000734925,"msg":"request completed"}
+{"level":30,"time":1743579817319,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-60","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":33524},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579817320,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-60","res":{"statusCode":200},"responseTime":0.7717720000073314,"msg":"request completed"}
+{"level":30,"time":1743579837322,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-63","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":50114},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579837323,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-63","res":{"statusCode":200},"responseTime":0.7177130000200123,"msg":"request completed"}
+{"level":30,"time":1743579857320,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-65","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60772},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579857321,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-65","res":{"statusCode":200},"responseTime":0.41482000006362796,"msg":"request completed"}
+{"level":30,"time":1743579877323,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-67","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":46756},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579877324,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-67","res":{"statusCode":200},"responseTime":0.39577000006102026,"msg":"request completed"}
+{"level":30,"time":1743579897324,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6a","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":37540},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579897325,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6a","res":{"statusCode":200},"responseTime":0.4045110000297427,"msg":"request completed"}
+{"level":30,"time":1743579917324,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6c","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":56636},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579917325,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6c","res":{"statusCode":200},"responseTime":0.6646640000399202,"msg":"request completed"}
+{"level":30,"time":1743579937328,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6e","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":41994},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579937329,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6e","res":{"statusCode":200},"responseTime":0.9722460000775754,"msg":"request completed"}
+{"level":30,"time":1743579957329,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6h","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":51576},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579957330,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6h","res":{"statusCode":200},"responseTime":0.41142999986186624,"msg":"request completed"}
+{"level":30,"time":1743579977327,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6j","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":55190},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579977328,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6j","res":{"statusCode":200},"responseTime":0.46381900017149746,"msg":"request completed"}
+{"level":30,"time":1743579997329,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6l","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60634},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743579997330,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6l","res":{"statusCode":200},"responseTime":0.6180950000416487,"msg":"request completed"}
+{"level":30,"time":1743580017331,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6o","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":38890},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580017332,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6o","res":{"statusCode":200},"responseTime":0.6232149999123067,"msg":"request completed"}
+{"level":30,"time":1743580037331,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6q","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":48990},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580037332,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6q","res":{"statusCode":200},"responseTime":0.6158450001385063,"msg":"request completed"}
+{"level":30,"time":1743580057334,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6s","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":40046},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580057335,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6s","res":{"statusCode":200},"responseTime":0.5542059997096658,"msg":"request completed"}
+{"level":30,"time":1743580077334,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6v","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":49952},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580077335,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6v","res":{"statusCode":200},"responseTime":0.3631910001859069,"msg":"request completed"}
+{"level":30,"time":1743580097334,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6x","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":44858},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580097335,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6x","res":{"statusCode":200},"responseTime":0.5997150000184774,"msg":"request completed"}
+{"level":30,"time":1743580117338,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6z","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":33192},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580117339,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-6z","res":{"statusCode":200},"responseTime":0.5860560000874102,"msg":"request completed"}
+{"level":30,"time":1743580137339,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-72","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":53302},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580137341,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-72","res":{"statusCode":200},"responseTime":0.7837709998711944,"msg":"request completed"}
+{"level":30,"time":1743580157340,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-74","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":47014},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580157341,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-74","res":{"statusCode":200},"responseTime":1.1337729999795556,"msg":"request completed"}
+{"level":30,"time":1743580177341,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-76","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":57828},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580177342,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-76","res":{"statusCode":200},"responseTime":0.6647239997982979,"msg":"request completed"}
+{"level":30,"time":1743580197343,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-79","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":35638},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580197344,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-79","res":{"statusCode":200},"responseTime":0.5747160003520548,"msg":"request completed"}
+{"level":30,"time":1743580217343,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7b","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":42698},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580217344,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7b","res":{"statusCode":200},"responseTime":0.6355840000323951,"msg":"request completed"}
+{"level":30,"time":1743580237345,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7d","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":45410},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580237345,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7d","res":{"statusCode":200},"responseTime":0.43893999978899956,"msg":"request completed"}
+{"level":30,"time":1743580257346,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7g","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60676},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580257347,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7g","res":{"statusCode":200},"responseTime":0.68220299994573,"msg":"request completed"}
+{"level":30,"time":1743580277346,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7i","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":33328},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580277347,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7i","res":{"statusCode":200},"responseTime":0.4670290001668036,"msg":"request completed"}
+{"level":30,"time":1743580297347,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7k","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":35574},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580297348,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7k","res":{"statusCode":200},"responseTime":0.7594420001842082,"msg":"request completed"}
+{"level":30,"time":1743580317347,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7n","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":47764},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580317348,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7n","res":{"statusCode":200},"responseTime":0.40010999981313944,"msg":"request completed"}
+{"level":30,"time":1743580337349,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7p","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":55150},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580337350,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7p","res":{"statusCode":200},"responseTime":0.5404869997873902,"msg":"request completed"}
+{"level":30,"time":1743580357352,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7r","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":35634},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580357353,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7r","res":{"statusCode":200},"responseTime":0.728023000061512,"msg":"request completed"}
+{"level":30,"time":1743580377354,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7u","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":54282},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580377355,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7u","res":{"statusCode":200},"responseTime":0.6135749998502433,"msg":"request completed"}
+{"level":30,"time":1743580397352,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7w","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":44324},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580397352,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7w","res":{"statusCode":200},"responseTime":0.4121799999848008,"msg":"request completed"}
+{"level":30,"time":1743580417355,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7y","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":41840},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580417356,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-7y","res":{"statusCode":200},"responseTime":0.6118749999441206,"msg":"request completed"}
+{"level":30,"time":1743580437357,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-81","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39860},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580437358,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-81","res":{"statusCode":200},"responseTime":0.5495870001614094,"msg":"request completed"}
+{"level":30,"time":1743580457357,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-83","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":46878},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580457358,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-83","res":{"statusCode":200},"responseTime":0.6630539996549487,"msg":"request completed"}
+{"level":30,"time":1743580477359,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-85","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39316},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580477360,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-85","res":{"statusCode":200},"responseTime":0.6043659998103976,"msg":"request completed"}
+{"level":30,"time":1743580497358,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-88","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":38854},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580497359,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-88","res":{"statusCode":200},"responseTime":0.6827840004116297,"msg":"request completed"}
+{"level":30,"time":1743580517361,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8a","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60932},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580517362,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8a","res":{"statusCode":200},"responseTime":1.0338550000451505,"msg":"request completed"}
+{"level":30,"time":1743580537362,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8c","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":41920},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580537363,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8c","res":{"statusCode":200},"responseTime":0.546697000041604,"msg":"request completed"}
+{"level":30,"time":1743580557362,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8f","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":49670},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580557363,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8f","res":{"statusCode":200},"responseTime":0.6389150000177324,"msg":"request completed"}
+{"level":30,"time":1743580577362,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8h","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":50514},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580577363,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8h","res":{"statusCode":200},"responseTime":0.6278140000067651,"msg":"request completed"}
+{"level":30,"time":1743580597364,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8j","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":35378},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580597366,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8j","res":{"statusCode":200},"responseTime":1.44899500021711,"msg":"request completed"}
+{"level":30,"time":1743580617366,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8m","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":47170},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580617367,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8m","res":{"statusCode":200},"responseTime":0.7151330001652241,"msg":"request completed"}
+{"level":30,"time":1743580637367,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8o","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":50812},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580637367,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8o","res":{"statusCode":200},"responseTime":0.5845150002278388,"msg":"request completed"}
+{"level":30,"time":1743580657369,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8q","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":45828},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580657370,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8q","res":{"statusCode":200},"responseTime":0.4169299998320639,"msg":"request completed"}
+{"level":30,"time":1743580677370,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8t","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60062},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580677370,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8t","res":{"statusCode":200},"responseTime":0.6576139996759593,"msg":"request completed"}
+{"level":30,"time":1743580697370,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8v","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":57600},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580697371,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8v","res":{"statusCode":200},"responseTime":0.7463920000009239,"msg":"request completed"}
+{"level":30,"time":1743580717371,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8x","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":34820},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580717372,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-8x","res":{"statusCode":200},"responseTime":0.5854850001633167,"msg":"request completed"}
+{"level":30,"time":1743580737376,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-90","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60060},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580737377,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-90","res":{"statusCode":200},"responseTime":0.7254130002111197,"msg":"request completed"}
+{"level":30,"time":1743580757375,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-92","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":56388},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580757378,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-92","res":{"statusCode":200},"responseTime":2.556408000178635,"msg":"request completed"}
+{"level":30,"time":1743580777377,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-94","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":41712},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580777378,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-94","res":{"statusCode":200},"responseTime":0.41338999988511205,"msg":"request completed"}
+{"level":30,"time":1743580797378,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-97","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":47626},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580797378,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-97","res":{"statusCode":200},"responseTime":0.42904999991878867,"msg":"request completed"}
+{"level":30,"time":1743580817377,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-99","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":42888},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580817377,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-99","res":{"statusCode":200},"responseTime":0.593915999867022,"msg":"request completed"}
+{"level":30,"time":1743580837381,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9b","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":55098},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580837381,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9b","res":{"statusCode":200},"responseTime":0.419129999820143,"msg":"request completed"}
+{"level":30,"time":1743580857382,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9e","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":38536},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580857383,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9e","res":{"statusCode":200},"responseTime":0.40096000023186207,"msg":"request completed"}
+{"level":30,"time":1743580877383,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9g","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60094},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580877383,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9g","res":{"statusCode":200},"responseTime":0.6421039998531342,"msg":"request completed"}
+{"level":30,"time":1743580897382,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9i","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39452},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580897384,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9i","res":{"statusCode":200},"responseTime":0.6376940002664924,"msg":"request completed"}
+{"level":30,"time":1743580917384,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9l","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":54558},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580917385,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9l","res":{"statusCode":200},"responseTime":0.5768659999594092,"msg":"request completed"}
+{"level":30,"time":1743580937384,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9n","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":41436},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580937385,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9n","res":{"statusCode":200},"responseTime":0.5508770002052188,"msg":"request completed"}
+{"level":30,"time":1743580957388,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9p","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":57434},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580957389,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9p","res":{"statusCode":200},"responseTime":0.615555000025779,"msg":"request completed"}
+{"level":30,"time":1743580977390,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9s","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":33116},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580977390,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9s","res":{"statusCode":200},"responseTime":0.43833000026643276,"msg":"request completed"}
+{"level":30,"time":1743580997390,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9u","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":57102},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743580997390,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9u","res":{"statusCode":200},"responseTime":0.4196489998139441,"msg":"request completed"}
+{"level":30,"time":1743581017392,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9w","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":48418},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581017393,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9w","res":{"statusCode":200},"responseTime":0.6614439999684691,"msg":"request completed"}
+{"level":30,"time":1743581037391,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9z","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":43682},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581037392,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-9z","res":{"statusCode":200},"responseTime":0.4978180001489818,"msg":"request completed"}
+{"level":30,"time":1743581057393,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-a1","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":54696},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581057394,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-a1","res":{"statusCode":200},"responseTime":0.6973529998213053,"msg":"request completed"}
+{"level":30,"time":1743581077395,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-a3","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":41252},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581077396,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-a3","res":{"statusCode":200},"responseTime":0.6054349998012185,"msg":"request completed"}
+{"level":30,"time":1743581097395,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-a6","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":54064},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581097396,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-a6","res":{"statusCode":200},"responseTime":0.4307900001294911,"msg":"request completed"}
+{"level":30,"time":1743581117395,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-a8","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60430},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581117396,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-a8","res":{"statusCode":200},"responseTime":0.698352999985218,"msg":"request completed"}
+{"level":30,"time":1743581137397,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-aa","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":36690},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581137398,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-aa","res":{"statusCode":200},"responseTime":0.5490669999271631,"msg":"request completed"}
+{"level":30,"time":1743581157399,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ad","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":33382},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581157400,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ad","res":{"statusCode":200},"responseTime":0.6712830001488328,"msg":"request completed"}
+{"level":30,"time":1743581177399,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-af","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39522},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581177400,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-af","res":{"statusCode":200},"responseTime":0.5872649997472763,"msg":"request completed"}
+{"level":30,"time":1743581197401,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ah","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39076},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581197401,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ah","res":{"statusCode":200},"responseTime":0.3831400000490248,"msg":"request completed"}
+{"level":30,"time":1743581217404,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ak","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":41774},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581217405,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ak","res":{"statusCode":200},"responseTime":0.4758589998818934,"msg":"request completed"}
+{"level":30,"time":1743581237405,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-am","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":43164},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581237406,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-am","res":{"statusCode":200},"responseTime":0.6064650001935661,"msg":"request completed"}
+{"level":30,"time":1743581257406,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ao","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":42752},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581257407,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ao","res":{"statusCode":200},"responseTime":0.4744389997795224,"msg":"request completed"}
+{"level":30,"time":1743581277408,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ar","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":56258},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581277409,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ar","res":{"statusCode":200},"responseTime":0.35555099975317717,"msg":"request completed"}
+{"level":30,"time":1743581297406,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-at","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":54756},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581297407,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-at","res":{"statusCode":200},"responseTime":0.39890099968761206,"msg":"request completed"}
+{"level":30,"time":1743581317410,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-av","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60056},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581317410,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-av","res":{"statusCode":200},"responseTime":0.5046279998496175,"msg":"request completed"}
+{"level":30,"time":1743581337410,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ay","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":44798},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581337412,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ay","res":{"statusCode":200},"responseTime":1.0562939997762442,"msg":"request completed"}
+{"level":30,"time":1743581357411,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-b0","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":57246},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581357412,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-b0","res":{"statusCode":200},"responseTime":0.7341319997794926,"msg":"request completed"}
+{"level":30,"time":1743581377411,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-b2","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":42688},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581377413,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-b2","res":{"statusCode":200},"responseTime":1.595071000047028,"msg":"request completed"}
+{"level":30,"time":1743581397415,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-b5","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":59770},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581397415,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-b5","res":{"statusCode":200},"responseTime":0.45339899975806475,"msg":"request completed"}
+{"level":30,"time":1743581417415,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-b7","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":37048},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581417415,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-b7","res":{"statusCode":200},"responseTime":0.45505900029093027,"msg":"request completed"}
+{"level":30,"time":1743581437417,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-b9","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":43738},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581437418,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-b9","res":{"statusCode":200},"responseTime":0.5287369997240603,"msg":"request completed"}
+{"level":30,"time":1743581457419,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bc","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":46732},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581457420,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bc","res":{"statusCode":200},"responseTime":0.6854530000127852,"msg":"request completed"}
+{"level":30,"time":1743581477417,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-be","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":41614},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581477418,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-be","res":{"statusCode":200},"responseTime":0.6398340002633631,"msg":"request completed"}
+{"level":30,"time":1743581497418,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bg","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":40622},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581497419,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bg","res":{"statusCode":200},"responseTime":0.6723229996860027,"msg":"request completed"}
+{"level":30,"time":1743581517420,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bj","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":49634},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581517421,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bj","res":{"statusCode":200},"responseTime":0.570785999763757,"msg":"request completed"}
+{"level":30,"time":1743581537420,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bl","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":51364},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581537422,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bl","res":{"statusCode":200},"responseTime":1.02480599982664,"msg":"request completed"}
+{"level":30,"time":1743581557424,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bn","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":49162},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581557425,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bn","res":{"statusCode":200},"responseTime":0.7630810001865029,"msg":"request completed"}
+{"level":30,"time":1743581577424,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bq","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39430},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581577425,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bq","res":{"statusCode":200},"responseTime":0.5490569998510182,"msg":"request completed"}
+{"level":30,"time":1743581597426,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bs","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":57640},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581597427,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bs","res":{"statusCode":200},"responseTime":0.6204149997793138,"msg":"request completed"}
+{"level":30,"time":1743581617428,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bu","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":50170},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581617429,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bu","res":{"statusCode":200},"responseTime":0.6130160000175238,"msg":"request completed"}
+{"level":30,"time":1743581637429,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bx","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":45368},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581637430,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bx","res":{"statusCode":200},"responseTime":0.5805259998887777,"msg":"request completed"}
+{"level":30,"time":1743581657429,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bz","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":36076},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581657429,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-bz","res":{"statusCode":200},"responseTime":0.4528290000744164,"msg":"request completed"}
+{"level":30,"time":1743581677431,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-c1","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":33898},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581677432,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-c1","res":{"statusCode":200},"responseTime":0.6865329998545349,"msg":"request completed"}
+{"level":30,"time":1743581697433,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-c4","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":33920},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581697434,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-c4","res":{"statusCode":200},"responseTime":0.6893040002323687,"msg":"request completed"}
+{"level":30,"time":1743581717432,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-c6","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":38490},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581717432,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-c6","res":{"statusCode":200},"responseTime":0.4503390002064407,"msg":"request completed"}
+{"level":30,"time":1743581737435,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-c8","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":46508},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581737435,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-c8","res":{"statusCode":200},"responseTime":0.4640089999884367,"msg":"request completed"}
+{"level":30,"time":1743581757437,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-cb","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":44532},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581757437,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-cb","res":{"statusCode":200},"responseTime":0.36927100038155913,"msg":"request completed"}
+{"level":30,"time":1743581777437,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-cd","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":46724},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581777438,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-cd","res":{"statusCode":200},"responseTime":0.6865630000829697,"msg":"request completed"}
+{"level":30,"time":1743581797438,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-cf","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":41666},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581797439,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-cf","res":{"statusCode":200},"responseTime":1.002026000060141,"msg":"request completed"}
+{"level":30,"time":1743581817438,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ci","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":54926},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581817439,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ci","res":{"statusCode":200},"responseTime":0.4037510002963245,"msg":"request completed"}
+{"level":30,"time":1743581837440,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ck","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":52758},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581837441,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ck","res":{"statusCode":200},"responseTime":0.37494099978357553,"msg":"request completed"}
+{"level":30,"time":1743581857440,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-cm","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39080},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581857441,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-cm","res":{"statusCode":200},"responseTime":0.5962760001420975,"msg":"request completed"}
+{"level":30,"time":1743581877441,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-cp","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":56086},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581877442,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-cp","res":{"statusCode":200},"responseTime":0.585705999750644,"msg":"request completed"}
+{"level":30,"time":1743581897443,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-cr","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":49874},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581897444,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-cr","res":{"statusCode":200},"responseTime":0.7415620000101626,"msg":"request completed"}
+{"level":30,"time":1743581917443,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ct","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":41442},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581917444,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ct","res":{"statusCode":200},"responseTime":0.40133999986574054,"msg":"request completed"}
+{"level":30,"time":1743581937447,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-cw","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":55338},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581937448,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-cw","res":{"statusCode":200},"responseTime":0.5558160003274679,"msg":"request completed"}
+{"level":30,"time":1743581957447,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-cy","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":59948},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581957447,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-cy","res":{"statusCode":200},"responseTime":0.386550999712199,"msg":"request completed"}
+{"level":30,"time":1743581977449,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-d0","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":47258},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581977450,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-d0","res":{"statusCode":200},"responseTime":0.6030660001561046,"msg":"request completed"}
+{"level":30,"time":1743581997451,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-d3","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":50258},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743581997451,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-d3","res":{"statusCode":200},"responseTime":0.5639559999108315,"msg":"request completed"}
+{"level":30,"time":1743582017451,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-d5","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":55418},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582017451,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-d5","res":{"statusCode":200},"responseTime":0.6029949998483062,"msg":"request completed"}
+{"level":30,"time":1743582037452,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-d7","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60096},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582037453,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-d7","res":{"statusCode":200},"responseTime":0.4793380000628531,"msg":"request completed"}
+{"level":30,"time":1743582057454,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-da","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":35320},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582057455,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-da","res":{"statusCode":200},"responseTime":0.5851449999026954,"msg":"request completed"}
+{"level":30,"time":1743582077452,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-dc","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":40258},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582077453,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-dc","res":{"statusCode":200},"responseTime":0.6394539996981621,"msg":"request completed"}
+{"level":30,"time":1743582097456,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-de","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":42362},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582097456,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-de","res":{"statusCode":200},"responseTime":0.43944900017231703,"msg":"request completed"}
+{"level":30,"time":1743582117457,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-dh","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":57628},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582117458,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-dh","res":{"statusCode":200},"responseTime":0.5310969999991357,"msg":"request completed"}
+{"level":30,"time":1743582137456,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-dj","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":58294},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582137457,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-dj","res":{"statusCode":200},"responseTime":0.6099359998479486,"msg":"request completed"}
+{"level":30,"time":1743582157457,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-dl","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39512},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582157458,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-dl","res":{"statusCode":200},"responseTime":0.6151649998500943,"msg":"request completed"}
+{"level":30,"time":1743582177461,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-do","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":34000},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582177461,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-do","res":{"statusCode":200},"responseTime":0.42714000027626753,"msg":"request completed"}
+{"level":30,"time":1743582197459,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-dq","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":43808},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582197460,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-dq","res":{"statusCode":200},"responseTime":0.5324870003387332,"msg":"request completed"}
+{"level":30,"time":1743582217463,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ds","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":35370},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582217463,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ds","res":{"statusCode":200},"responseTime":0.5780760003253818,"msg":"request completed"}
+{"level":30,"time":1743582237464,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-dv","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":47496},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582237465,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-dv","res":{"statusCode":200},"responseTime":0.3674709992483258,"msg":"request completed"}
+{"level":30,"time":1743582257465,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-dx","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60412},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582257465,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-dx","res":{"statusCode":200},"responseTime":0.43149999994784594,"msg":"request completed"}
+{"level":30,"time":1743582277465,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-dz","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":47550},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582277466,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-dz","res":{"statusCode":200},"responseTime":0.5684359995648265,"msg":"request completed"}
+{"level":30,"time":1743582297468,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-e2","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":53332},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582297469,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-e2","res":{"statusCode":200},"responseTime":0.5885159997269511,"msg":"request completed"}
+{"level":30,"time":1743582317468,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-e4","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":36720},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582317469,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-e4","res":{"statusCode":200},"responseTime":0.6862340001389384,"msg":"request completed"}
+{"level":30,"time":1743582337468,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-e6","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":35336},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582337469,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-e6","res":{"statusCode":200},"responseTime":0.8500499995425344,"msg":"request completed"}
+{"level":30,"time":1743582357472,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-e9","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39222},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582357472,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-e9","res":{"statusCode":200},"responseTime":0.42722999956458807,"msg":"request completed"}
+{"level":30,"time":1743582377470,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-eb","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":51258},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582377471,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-eb","res":{"statusCode":200},"responseTime":1.0197350000962615,"msg":"request completed"}
+{"level":30,"time":1743582397471,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ed","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":46116},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582397472,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ed","res":{"statusCode":200},"responseTime":0.6429249998182058,"msg":"request completed"}
+{"level":30,"time":1743582417473,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-eg","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":35528},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582417474,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-eg","res":{"statusCode":200},"responseTime":0.5284970002248883,"msg":"request completed"}
+{"level":30,"time":1743582437475,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ei","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":59988},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582437475,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ei","res":{"statusCode":200},"responseTime":0.39775999914854765,"msg":"request completed"}
+{"level":30,"time":1743582457477,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ek","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":43806},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582457478,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ek","res":{"statusCode":200},"responseTime":0.619874999858439,"msg":"request completed"}
+{"level":30,"time":1743582477477,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-en","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":37374},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582477478,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-en","res":{"statusCode":200},"responseTime":0.539377000182867,"msg":"request completed"}
+{"level":30,"time":1743582497477,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ep","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":47524},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582497478,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ep","res":{"statusCode":200},"responseTime":0.5644169999286532,"msg":"request completed"}
+{"level":30,"time":1743582517478,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-er","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":50390},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582517479,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-er","res":{"statusCode":200},"responseTime":0.4973879996687174,"msg":"request completed"}
+{"level":30,"time":1743582537480,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-eu","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":43950},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582537481,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-eu","res":{"statusCode":200},"responseTime":0.48619799967855215,"msg":"request completed"}
+{"level":30,"time":1743582557482,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ew","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":59994},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582557483,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ew","res":{"statusCode":200},"responseTime":0.49474800005555153,"msg":"request completed"}
+{"level":30,"time":1743582577482,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ey","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":49692},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582577482,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ey","res":{"statusCode":200},"responseTime":0.44263899978250265,"msg":"request completed"}
+{"level":30,"time":1743582597486,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-f1","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":34586},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582597486,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-f1","res":{"statusCode":200},"responseTime":0.38805099949240685,"msg":"request completed"}
+{"level":30,"time":1743582617484,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-f3","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":49710},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582617485,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-f3","res":{"statusCode":200},"responseTime":0.6242849994450808,"msg":"request completed"}
+{"level":30,"time":1743582637486,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-f5","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39340},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582637486,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-f5","res":{"statusCode":200},"responseTime":0.5207170005887747,"msg":"request completed"}
+{"level":30,"time":1743582657487,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-f8","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":43080},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582657488,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-f8","res":{"statusCode":200},"responseTime":0.5238180002197623,"msg":"request completed"}
+{"level":30,"time":1743582677488,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-fa","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":46360},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582677489,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-fa","res":{"statusCode":200},"responseTime":0.5324569996446371,"msg":"request completed"}
+{"level":30,"time":1743582697489,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-fc","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":44944},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582697490,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-fc","res":{"statusCode":200},"responseTime":0.7059130007401109,"msg":"request completed"}
+{"level":30,"time":1743582717493,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ff","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60194},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582717494,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ff","res":{"statusCode":200},"responseTime":0.5380870001390576,"msg":"request completed"}
+{"level":30,"time":1743582737491,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-fh","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":52864},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582737491,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-fh","res":{"statusCode":200},"responseTime":0.3608619999140501,"msg":"request completed"}
+{"level":30,"time":1743582757495,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-fj","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":48758},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582757495,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-fj","res":{"statusCode":200},"responseTime":0.5313869994133711,"msg":"request completed"}
+{"level":30,"time":1743582777496,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-fm","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":54846},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582777496,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-fm","res":{"statusCode":200},"responseTime":0.4504490001127124,"msg":"request completed"}
+{"level":30,"time":1743582797495,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-fo","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":38344},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582797497,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-fo","res":{"statusCode":200},"responseTime":1.455945000052452,"msg":"request completed"}
+{"level":30,"time":1743582817498,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-fq","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":52464},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582817499,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-fq","res":{"statusCode":200},"responseTime":0.3809110000729561,"msg":"request completed"}
+{"level":30,"time":1743582837500,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ft","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":59458},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582837501,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ft","res":{"statusCode":200},"responseTime":0.37134100031107664,"msg":"request completed"}
+{"level":30,"time":1743582857500,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-fv","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":43962},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582857501,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-fv","res":{"statusCode":200},"responseTime":0.4511789996176958,"msg":"request completed"}
+{"level":30,"time":1743582877500,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-fx","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":57560},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582877501,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-fx","res":{"statusCode":200},"responseTime":0.5714059993624687,"msg":"request completed"}
+{"level":30,"time":1743582897504,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-g0","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":51080},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582897505,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-g0","res":{"statusCode":200},"responseTime":0.5577469998970628,"msg":"request completed"}
+{"level":30,"time":1743582917502,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-g2","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":42906},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582917503,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-g2","res":{"statusCode":200},"responseTime":0.48112899996340275,"msg":"request completed"}
+{"level":30,"time":1743582937506,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-g4","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39374},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582937507,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-g4","res":{"statusCode":200},"responseTime":0.5644460003823042,"msg":"request completed"}
+{"level":30,"time":1743582957506,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-g7","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":37236},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582957507,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-g7","res":{"statusCode":200},"responseTime":0.4807890001684427,"msg":"request completed"}
+{"level":30,"time":1743582977507,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-g9","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":56740},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582977507,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-g9","res":{"statusCode":200},"responseTime":0.5761160003021359,"msg":"request completed"}
+{"level":30,"time":1743582997510,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gb","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":47956},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743582997511,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gb","res":{"statusCode":200},"responseTime":0.43072899989783764,"msg":"request completed"}
+{"level":30,"time":1743583017510,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ge","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":54776},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583017510,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ge","res":{"statusCode":200},"responseTime":0.5246279994025826,"msg":"request completed"}
+{"level":30,"time":1743583037509,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gg","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":37448},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583037510,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gg","res":{"statusCode":200},"responseTime":0.5803160006180406,"msg":"request completed"}
+{"level":30,"time":1743583057513,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gi","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":48666},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583057514,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gi","res":{"statusCode":200},"responseTime":0.7880710000172257,"msg":"request completed"}
+{"level":30,"time":1743583077513,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gl","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":45956},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583077516,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gl","res":{"statusCode":200},"responseTime":2.627246000804007,"msg":"request completed"}
+{"level":30,"time":1743583097514,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gn","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":54670},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583097515,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gn","res":{"statusCode":200},"responseTime":0.7548310002312064,"msg":"request completed"}
+{"level":30,"time":1743583117517,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gp","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":40026},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583117517,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gp","res":{"statusCode":200},"responseTime":0.517408000305295,"msg":"request completed"}
+{"level":30,"time":1743583137517,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gs","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":52188},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583137518,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gs","res":{"statusCode":200},"responseTime":0.6022950001060963,"msg":"request completed"}
+{"level":30,"time":1743583157518,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gu","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":44952},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583157519,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gu","res":{"statusCode":200},"responseTime":0.41391999926418066,"msg":"request completed"}
+{"level":30,"time":1743583177520,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gw","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":55998},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583177521,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gw","res":{"statusCode":200},"responseTime":0.6555139999836683,"msg":"request completed"}
+{"level":30,"time":1743583197522,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gz","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":55310},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583197523,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-gz","res":{"statusCode":200},"responseTime":0.6302339993417263,"msg":"request completed"}
+{"level":30,"time":1743583217520,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-h1","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":55630},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583217521,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-h1","res":{"statusCode":200},"responseTime":0.39190000016242266,"msg":"request completed"}
+{"level":30,"time":1743583237524,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-h3","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":33338},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583237525,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-h3","res":{"statusCode":200},"responseTime":0.5292469998821616,"msg":"request completed"}
+{"level":30,"time":1743583257524,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-h6","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":49008},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583257525,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-h6","res":{"statusCode":200},"responseTime":0.5873060002923012,"msg":"request completed"}
+{"level":30,"time":1743583277526,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-h8","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":44154},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583277526,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-h8","res":{"statusCode":200},"responseTime":0.5021579992026091,"msg":"request completed"}
+{"level":30,"time":1743583297528,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ha","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":60054},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583297528,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ha","res":{"statusCode":200},"responseTime":0.5849060006439686,"msg":"request completed"}
+{"level":30,"time":1743583317528,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-hd","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":58056},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583317529,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-hd","res":{"statusCode":200},"responseTime":0.5812060004100204,"msg":"request completed"}
+{"level":30,"time":1743583337529,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-hf","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":36410},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583337530,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-hf","res":{"statusCode":200},"responseTime":0.5973249999806285,"msg":"request completed"}
+{"level":30,"time":1743583357529,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-hh","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39988},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583357530,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-hh","res":{"statusCode":200},"responseTime":0.581445999443531,"msg":"request completed"}
+{"level":30,"time":1743583377533,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-hk","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":35240},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583377533,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-hk","res":{"statusCode":200},"responseTime":0.422800000756979,"msg":"request completed"}
+{"level":30,"time":1743583397533,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-hm","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":49344},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583397533,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-hm","res":{"statusCode":200},"responseTime":0.438570000231266,"msg":"request completed"}
+{"level":30,"time":1743583417533,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ho","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":50250},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583417534,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ho","res":{"statusCode":200},"responseTime":0.6901230001822114,"msg":"request completed"}
+{"level":30,"time":1743583437535,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-hr","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":44836},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583437535,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-hr","res":{"statusCode":200},"responseTime":0.5239079995080829,"msg":"request completed"}
+{"level":30,"time":1743583457537,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ht","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":36358},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583457537,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ht","res":{"statusCode":200},"responseTime":0.5629559997469187,"msg":"request completed"}
+{"level":30,"time":1743583477536,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-hv","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":36688},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583477537,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-hv","res":{"statusCode":200},"responseTime":0.6874430002644658,"msg":"request completed"}
+{"level":30,"time":1743583497538,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-hy","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":40038},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583497539,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-hy","res":{"statusCode":200},"responseTime":0.7858410002663732,"msg":"request completed"}
+{"level":30,"time":1743583517540,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-i0","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":34062},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583517541,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-i0","res":{"statusCode":200},"responseTime":0.6644439995288849,"msg":"request completed"}
+{"level":30,"time":1743583537540,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-i2","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":42910},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583537541,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-i2","res":{"statusCode":200},"responseTime":0.6230349997058511,"msg":"request completed"}
+{"level":30,"time":1743583557544,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-i5","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39498},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583557544,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-i5","res":{"statusCode":200},"responseTime":0.4975279998034239,"msg":"request completed"}
+{"level":30,"time":1743583577544,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-i7","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":36216},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583577545,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-i7","res":{"statusCode":200},"responseTime":0.5902950000017881,"msg":"request completed"}
+{"level":30,"time":1743583597544,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-i9","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":34482},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583597544,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-i9","res":{"statusCode":200},"responseTime":0.5596070000901818,"msg":"request completed"}
+{"level":30,"time":1743583617545,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ic","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":41368},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583617546,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ic","res":{"statusCode":200},"responseTime":0.4602190004661679,"msg":"request completed"}
+{"level":30,"time":1743583637546,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ie","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":37928},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583637547,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ie","res":{"statusCode":200},"responseTime":0.6112150000408292,"msg":"request completed"}
+{"level":30,"time":1743583657547,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ig","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":42100},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583657548,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ig","res":{"statusCode":200},"responseTime":0.631173999980092,"msg":"request completed"}
+{"level":30,"time":1743583677551,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ij","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":47516},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583677552,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ij","res":{"statusCode":200},"responseTime":0.5461170002818108,"msg":"request completed"}
+{"level":30,"time":1743583697551,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-il","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":37248},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583697552,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-il","res":{"statusCode":200},"responseTime":0.6160350004211068,"msg":"request completed"}
+{"level":30,"time":1743583717553,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-in","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":34310},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583717553,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-in","res":{"statusCode":200},"responseTime":0.44127900060266256,"msg":"request completed"}
+{"level":30,"time":1743583737552,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-iq","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":51540},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583737553,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-iq","res":{"statusCode":200},"responseTime":0.5491169998422265,"msg":"request completed"}
+{"level":30,"time":1743583757553,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-is","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":53824},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583757553,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-is","res":{"statusCode":200},"responseTime":0.5452370001003146,"msg":"request completed"}
+{"level":30,"time":1743583777556,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-iu","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":35696},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583777557,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-iu","res":{"statusCode":200},"responseTime":0.529746999964118,"msg":"request completed"}
+{"level":30,"time":1743583797558,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ix","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":46472},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583797559,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-ix","res":{"statusCode":200},"responseTime":0.5628169998526573,"msg":"request completed"}
+{"level":30,"time":1743583817556,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-iz","req":{"method":"GET","url":"/fraud/health","host":"10.244.1.13:3005","remoteAddress":"10.244.1.1","remotePort":39088},"msg":"incoming request"}
+** headers health -> undefined
+{"level":30,"time":1743583817557,"pid":1,"hostname":"fraud-service-54df9b7d75-z6m75","reqId":"req-iz","res":{"statusCode":200},"responseTime":0.44953899923712015,"msg":"request completed"}
+
+stderr:

--- a/tests/llm/fixtures/test_ask_holmes/36_argocd_find_resource/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/36_argocd_find_resource/test_case.yaml
@@ -1,0 +1,7 @@
+# setup steps: https://gist.github.com/nherment/1d775ce7565113602639ca3de2f52153
+user_prompt: "what's wrong with the demo-app?"
+expected_output:
+  - Mention of my-demoshop-namespaces not found
+evaluation:
+  correctness: 1
+generate_mocks: False

--- a/tests/llm/fixtures/test_ask_holmes/37_argocd_wrong_namespace/argocd_app_diff.txt
+++ b/tests/llm/fixtures/test_ask_holmes/37_argocd_wrong_namespace/argocd_app_diff.txt
@@ -1,0 +1,25 @@
+{"toolset_name":"argocd/core","tool_name":"argocd_app_diff","match_params":{"app_name":"argocd/demo-app"}}
+Command `argocd app diff argocd/demo-app` failed with return code 1
+stdout:
+
+===== /Service my-demoshop-namespaces/auth-service ======
+0a1,17
+> apiVersion: v1
+> kind: Service
+> metadata:
+>   labels:
+>     app: demoshop
+>     app.kubernetes.io/instance: demo-app
+>     service: auth
+>   name: auth-service
+>   namespace: my-demoshop-namespaces
+> spec:
+>   ports:
+>   - name: http
+>     port: 3006
+>     targetPort: 3006
+>   selector:
+>     app: demoshop
+>     service: auth
+
+stderr:

--- a/tests/llm/fixtures/test_ask_holmes/37_argocd_wrong_namespace/argocd_app_get.txt
+++ b/tests/llm/fixtures/test_ask_holmes/37_argocd_wrong_namespace/argocd_app_get.txt
@@ -1,0 +1,40 @@
+{"toolset_name":"argocd/core","tool_name":"argocd_app_get","match_params":{"app_name":"argocd/demo-app"}}
+stdout:
+Name:               argocd/demo-app
+Project:            default
+Server:             https://kubernetes.default.svc
+Namespace:          
+URL:                https://127.0.0.1:40241/applications/demo-app
+Source:
+- Repo:             https://github.com/Arkhaios-AB/devops-demo
+  Target:           HEAD
+  Path:             .
+SyncWindow:         Sync Allowed
+Sync Policy:        Manual
+Sync Status:        OutOfSync from HEAD (b882d15)
+Health Status:      Missing
+
+Operation:          Sync
+Sync Revision:      b882d1517b40b4a39affad62cff19eb4a14ee43a
+Phase:              Failed
+Start:              2025-04-02 09:15:08 +0200 CEST
+Finished:           2025-04-02 09:15:09 +0200 CEST
+Duration:           1s
+Message:            one or more objects failed to apply, reason: namespaces "my-demoshop-namespaces" not found
+
+GROUP                  KIND            NAMESPACE               NAME                       STATUS     HEALTH   HOOK  MESSAGE
+                       Namespace                               my-demoshop-namespace      Synced                    namespace/my-demoshop-namespace unchanged
+                       Service         my-demoshop-namespace   fraud-service              Synced     Healthy        service/fraud-service unchanged
+                       Service         my-demoshop-namespace   checkout-service           Synced     Healthy        service/checkout-service unchanged
+                       Service         my-demoshop-namespace   backend-service            Synced     Healthy        service/backend-service unchanged
+                       Service         my-demoshop-namespaces  auth-service               OutOfSync  Missing        namespaces "my-demoshop-namespaces" not found
+apps                   Deployment      my-demoshop-namespace   backend-service            Synced     Healthy        deployment.apps/backend-service unchanged
+apps                   Deployment      my-demoshop-namespace   auth-service               Synced     Healthy        deployment.apps/auth-service unchanged
+apps                   Deployment      my-demoshop-namespace   fraud-service              Synced     Healthy        deployment.apps/fraud-service unchanged
+apps                   Deployment      my-demoshop-namespace   checkout-service           Synced     Healthy        deployment.apps/checkout-service unchanged
+monitoring.coreos.com  ServiceMonitor  my-demoshop-namespace   demoshop-services          Synced                    servicemonitor.monitoring.coreos.com/demoshop-services unchanged
+monitoring.coreos.com  PrometheusRule  my-demoshop-namespace   test-nicolas-high-latency  Synced                    prometheusrule.monitoring.coreos.com/test-nicolas-high-latency unchanged
+
+stderr:
+E0402 11:09:22.609848  233081 portforward.go:398] "Unhandled Error" err="error copying from local connection to remote stream: writeto tcp4 127.0.0.1:40241->127.0.0.1:34712: read tcp4 127.0.0.1:40241->127.0.0.1:34712: read: connection reset by peer" logger="UnhandledError"
+E0402 11:09:22.610700  233081 portforward.go:385] "Unhandled Error" err="error copying from remote stream to local connection: readfrom tcp4 127.0.0.1:40241->127.0.0.1:34712: write tcp4 127.0.0.1:40241->127.0.0.1:34712: write: broken pipe" logger="UnhandledError"

--- a/tests/llm/fixtures/test_ask_holmes/37_argocd_wrong_namespace/argocd_app_list.txt
+++ b/tests/llm/fixtures/test_ask_holmes/37_argocd_wrong_namespace/argocd_app_list.txt
@@ -1,0 +1,6 @@
+{"toolset_name":"argocd/core","tool_name":"argocd_app_list","match_params":{}}
+stdout:
+NAME             CLUSTER                         NAMESPACE  PROJECT  STATUS     HEALTH   SYNCPOLICY  CONDITIONS  REPO                                        PATH  TARGET
+argocd/demo-app  https://kubernetes.default.svc             default  OutOfSync  Missing  Manual      <none>      https://github.com/Arkhaios-AB/devops-demo  .     HEAD
+
+stderr:

--- a/tests/llm/fixtures/test_ask_holmes/37_argocd_wrong_namespace/argocd_app_manifests.txt
+++ b/tests/llm/fixtures/test_ask_holmes/37_argocd_wrong_namespace/argocd_app_manifests.txt
@@ -1,0 +1,345 @@
+{"toolset_name":"argocd/core","tool_name":"argocd_app_manifests","match_params":{"app_name":"argocd/demo-app"}}
+stdout:
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/instance: demo-app
+  name: my-demoshop-namespace
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: demoshop
+    app.kubernetes.io/instance: demo-app
+    service: backend
+  name: backend-service
+  namespace: my-demoshop-namespace
+spec:
+  ports:
+  - name: http
+    port: 3003
+    targetPort: 3003
+  selector:
+    app: demoshop
+    service: backend
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: demoshop
+    app.kubernetes.io/instance: demo-app
+    service: checkout
+  name: checkout-service
+  namespace: my-demoshop-namespace
+spec:
+  ports:
+  - name: http
+    port: 3004
+    targetPort: 3004
+  selector:
+    app: demoshop
+    service: checkout
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: demoshop
+    app.kubernetes.io/instance: demo-app
+    service: fraud
+  name: fraud-service
+  namespace: my-demoshop-namespace
+spec:
+  ports:
+  - name: http
+    port: 3005
+    targetPort: 3005
+  selector:
+    app: demoshop
+    service: fraud
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: demoshop
+    app.kubernetes.io/instance: demo-app
+    service: auth
+  name: auth-service
+  namespace: my-demoshop-namespaces
+spec:
+  ports:
+  - name: http
+    port: 3006
+    targetPort: 3006
+  selector:
+    app: demoshop
+    service: auth
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: demoshop
+    app.kubernetes.io/instance: demo-app
+    service: auth
+  name: auth-service
+  namespace: my-demoshop-namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demoshop
+      service: auth
+  template:
+    metadata:
+      labels:
+        app: demoshop
+        service: auth
+    spec:
+      containers:
+      - command:
+        - node
+        - --require
+        - ./dist/telemetry.js
+        - ./dist/auth-service.js
+        env:
+        - name: TEMPO_URL
+          value: http://opentelemetry-collector-agent.tt:4318/v1/traces
+        - name: SERVICE_NAME
+          value: auth-service
+        image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/shop-app-demo:v1
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /auth/health
+            port: 3006
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: auth
+        ports:
+        - containerPort: 3006
+          name: http
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: demoshop
+    app.kubernetes.io/instance: demo-app
+    service: backend
+  name: backend-service
+  namespace: my-demoshop-namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demoshop
+      service: backend
+  template:
+    metadata:
+      labels:
+        app: demoshop
+        service: backend
+    spec:
+      containers:
+      - command:
+        - node
+        - --require
+        - ./dist/telemetry.js
+        - ./dist/backend-service.js
+        env:
+        - name: TEMPO_URL
+          value: http://opentelemetry-collector-agent.tt:4318/v1/traces
+        - name: SERVICE_NAME
+          value: backend-service
+        image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/shop-app-demo:v1
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /backend/health
+            port: 3003
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: backend
+        ports:
+        - containerPort: 3003
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /backend/health
+            port: 3003
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 200m
+            memory: 256Mi
+      - args:
+        - |
+          while true; do
+            curl -X POST \
+            -H "Content-Type: application/json" \
+            -d '{"name":"John Doe","email":"john.doe@example.com","address":"main street","cardNumber":"1234-5678-9101-1121"}' \
+            http://localhost:3003/backend/api/checkout;
+            sleep 5;
+          done
+        command:
+        - /bin/sh
+        - -c
+        image: curlimages/curl:7.86.0
+        name: checkout-sidecar
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: demoshop
+    app.kubernetes.io/instance: demo-app
+    service: checkout
+  name: checkout-service
+  namespace: my-demoshop-namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demoshop
+      service: checkout
+  template:
+    metadata:
+      labels:
+        app: demoshop
+        service: checkout
+    spec:
+      containers:
+      - command:
+        - node
+        - --require
+        - ./dist/telemetry.js
+        - ./dist/checkout-service.js
+        env:
+        - name: TEMPO_URL
+          value: http://opentelemetry-collector-agent.tt:4318/v1/traces
+        - name: SERVICE_NAME
+          value: checkout-service
+        image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/shop-app-demo:v1
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /checkout/health
+            port: 3004
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: checkout
+        ports:
+        - containerPort: 3004
+          name: http
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: demoshop
+    app.kubernetes.io/instance: demo-app
+    service: fraud
+  name: fraud-service
+  namespace: my-demoshop-namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demoshop
+      service: fraud
+  template:
+    metadata:
+      labels:
+        app: demoshop
+        service: fraud
+    spec:
+      containers:
+      - command:
+        - node
+        - --require
+        - ./dist/telemetry.js
+        - ./dist/fraud-service.js
+        env:
+        - name: TEMPO_URL
+          value: http://opentelemetry-collector-agent.tt:4318/v1/traces
+        - name: SERVICE_NAME
+          value: fraud-service
+        image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/shop-app-demo:v1
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /fraud/health
+            port: 3005
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: fraud
+        ports:
+        - containerPort: 3005
+          name: http
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app: demoshop
+    app.kubernetes.io/instance: demo-app
+    release: robusta
+    role: alert-rules
+  name: test-nicolas-high-latency
+  namespace: my-demoshop-namespace
+spec:
+  groups:
+  - name: demoshop.rules
+    rules:
+    - alert: TestHighLatencyNicolas
+      annotations:
+        description: The service is experiencing high latency (> 4s 90% percentile)
+        summary: High latency detected in demoshop application
+      expr: histogram_quantile(0.9, sum(rate(http_request_duration_seconds_bucket[5m]))
+        by (le)) > 4
+      labels:
+        severity: warning
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: demoshop
+    app.kubernetes.io/instance: demo-app
+    release: robusta
+  name: demoshop-services
+  namespace: my-demoshop-namespace
+spec:
+  endpoints:
+  - interval: 15s
+    path: /metrics
+    port: http
+  namespaceSelector:
+    matchNames:
+    - my-demoshop-namespace
+  selector:
+    matchLabels:
+      app: demoshop
+
+
+stderr:

--- a/tests/llm/fixtures/test_ask_holmes/37_argocd_wrong_namespace/argocd_app_resources.txt
+++ b/tests/llm/fixtures/test_ask_holmes/37_argocd_wrong_namespace/argocd_app_resources.txt
@@ -1,0 +1,16 @@
+{"toolset_name":"argocd/core","tool_name":"argocd_app_resources","match_params":{"app_name":"argocd/demo-app"}}
+stdout:
+GROUP                  KIND            NAMESPACE               NAME                       ORPHANED
+                       Namespace                               my-demoshop-namespace      No
+                       Service         my-demoshop-namespace   backend-service            No
+                       Service         my-demoshop-namespace   checkout-service           No
+                       Service         my-demoshop-namespace   fraud-service              No
+                       Service         my-demoshop-namespaces  auth-service               No
+apps                   Deployment      my-demoshop-namespace   auth-service               No
+apps                   Deployment      my-demoshop-namespace   backend-service            No
+apps                   Deployment      my-demoshop-namespace   checkout-service           No
+apps                   Deployment      my-demoshop-namespace   fraud-service              No
+monitoring.coreos.com  PrometheusRule  my-demoshop-namespace   test-nicolas-high-latency  No
+monitoring.coreos.com  ServiceMonitor  my-demoshop-namespace   demoshop-services          No
+
+stderr:

--- a/tests/llm/fixtures/test_ask_holmes/37_argocd_wrong_namespace/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/37_argocd_wrong_namespace/test_case.yaml
@@ -1,0 +1,7 @@
+# setup steps: https://gist.github.com/nherment/1d775ce7565113602639ca3de2f52153
+user_prompt: "what's wrong with the argocd app `demo-app`?"
+expected_output:
+  - "`my-demoshop-namespaces` should be `my-demoshop-namespace`"
+evaluation:
+  correctness: 0
+generate_mocks: False


### PR DESCRIPTION
- Add 2 evals for argoCD
- Add llm instructions for holmes to properly use argocd
- Change how toolset specific llm instructions are loaded so that yaml toolsets benefit from jinja2 templating