### PR TITLE
Fix brew build

### DIFF
--- a/.github/workflows/build-binaries-and-brew.yaml
+++ b/.github/workflows/build-binaries-and-brew.yaml
@@ -71,12 +71,7 @@ jobs:
         pyinstaller holmes.py \
           --add-data 'holmes/plugins/runbooks/*:holmes/plugins/runbooks' \
           --add-data 'holmes/plugins/prompts/*:holmes/plugins/prompts' \
-          --add-data 'holmes/plugins/toolsets/*:holmes/plugins/toolsets' \
-          --add-data 'holmes/plugins/toolsets/coralogix*:holmes/plugins/toolsets/coralogix' \
-          --add-data 'holmes/plugins/toolsets/grafana*:holmes/plugins/toolsets/grafana' \
-          --add-data 'holmes/plugins/toolsets/internet*:holmes/plugins/toolsets/internet' \
-          --add-data 'holmes/plugins/toolsets/opensearch*:holmes/plugins/toolsets/opensearch' \
-          --add-data 'holmes/plugins/toolsets/prometheus*:holmes/plugins/toolsets/prometheus' \
+          --add-data 'holmes/plugins/toolsets:holmes/plugins/toolsets' \
           --hidden-import=tiktoken_ext.openai_public \
           --hidden-import=tiktoken_ext \
           --hiddenimport litellm.llms.tokenizers \


### PR DESCRIPTION
It didn't add all toolset directories to the binary by default - only manually configured directories
the robusta tool directory was added and broke the binary since it was missing the files,
Now will automatically add new tool directories