### PR TITLE
chore(toolset): add Azure Kubernetes Service toolset

### DIFF
--- a/holmes/plugins/toolsets/aks.yaml
+++ b/holmes/plugins/toolsets/aks.yaml
@@ -1,0 +1,55 @@
+toolsets:
+  aks/core:
+    description: "Set of tools to read Azure Kubernetes Service resources"
+    tags:
+      - cli
+    prerequisites:
+      - command: "az aks --help"
+      - command: "kubectl version --client"
+
+    tools:
+      - name: "cloud_provider"
+        description: "Fetches the cloud provider of the kubernetes cluster, determined by the providerID of the nodes"
+        user_description: "get cloud provider of AKS cluster"
+        command: |
+          kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.providerID}{"\n"}{end}'
+      - name: "aks_show_cluster"
+        description: "Fetches the configuration of a specific AKS cluster"
+        user_description: "get AKS cluster {{ CLUSTER_NAME }} under resource group {{RESOURCE_GROUP_NAME}} in subscription {{SUBSCRIPTION_ID}}"
+        command: |
+          az aks show --resource-group {{RESOURCE_GROUP_NAME}} --name {{CLUSTER_NAME}} --subscription {{SUBSCRIPTION_ID}}
+      - name: "aks_list_clusters"
+        description: "Lists all AKS clusters under a subscription"
+        user_description: "list AKS clusters under subscription {{ SUBSCRIPTION_ID }}"
+        command: |
+          az aks list --subscription {{ SUBSCRIPTION_ID }}
+      - name: "aks_list_clusters_by_rg"
+        description: "Lists all AKS clusters under a specific resource group"
+        user_description: "list AKS clusters in resource group {{ RESOURCE_GROUP_NAME }} under subscription {{ SUBSCRIPTION_ID }}"
+        command: |
+          az aks list --resource-group {{ RESOURCE_GROUP_NAME }} --subscription {{ SUBSCRIPTION_ID }}
+      - name: "aks_list_node_pools"
+        description: "Lists node pools in an AKS cluster"
+        user_description: "list node pools for AKS cluster {{ CLUSTER_NAME }} under resource group {{ RESOURCE_GROUP_NAME }}"
+        command: |
+          az aks nodepool list --resource-group {{ RESOURCE_GROUP_NAME }} --cluster-name {{ CLUSTER_NAME }} --subscription {{ SUBSCRIPTION_ID }}
+      - name: "aks_show_node_pool"
+        description: "Shows details of a specific node pool in an AKS cluster"
+        user_description: "get node pool {{ NODE_POOL_NAME }} in AKS cluster {{ CLUSTER_NAME }} under resource group {{ RESOURCE_GROUP_NAME }}"
+        command: |
+          az aks nodepool show --resource-group {{ RESOURCE_GROUP_NAME }} --cluster-name {{ CLUSTER_NAME }} --name {{ NODE_POOL_NAME }} --subscription {{ SUBSCRIPTION_ID }}
+      - name: "aks_list_versions"
+        description: "Lists supported Kubernetes versions in a region"
+        user_description: "list supported Kubernetes versions for region {{ LOCATION }}"
+        command: |
+          az aks get-versions --location {{ LOCATION }} --subscription {{ SUBSCRIPTION_ID }}
+      - name: "aks_get_credentials"
+        description: "Downloads kubeconfig file for an AKS cluster"
+        user_description: "get kubeconfig credentials for AKS cluster {{ CLUSTER_NAME }} under resource group {{ RESOURCE_GROUP_NAME }}"
+        command: |
+          az aks get-credentials --resource-group {{ RESOURCE_GROUP_NAME }} --name {{ CLUSTER_NAME }} --subscription {{ SUBSCRIPTION_ID }}
+      - name: "aks_list_addons"
+        description: "Lists all available AKS addons"
+        user_description: "list available addons for AKS in region {{ LOCATION }}"
+        command: |
+          az aks get-versions --location {{ LOCATION }} --query "orchestrators[].addons"


### PR DESCRIPTION
This PR adds a list of read operations to Azure Kubernetes Service Services. Also, a cloud_provider tool is added to determined the cloud provider of the Kubernetes cluster in current context before we can have a toolset somewhere to host cloud provider related tools