### PR TITLE
chore: infer filtered or function-guarded yaml tool parameter

### DIFF
--- a/holmes/core/tools.py
+++ b/holmes/core/tools.py
@@ -151,7 +151,7 @@ class YAMLTool(Tool, BaseModel):
     def __infer_parameters(self):
         # Find parameters that appear inside self.command or self.script but weren't declared in parameters
         template = self.command or self.script
-        inferred_params = re.findall(r"\{\{\s*(\w+)\s*\}\}", template)
+        inferred_params = re.findall(r"\{\{\s*([\w]+)[\.\|]?.*?\s*\}\}", template)
         # TODO: if filters were used in template, take only the variable name
         # Regular expression to match Jinja2 placeholders with or without filters
         # inferred_params = re.findall(r'\{\{\s*(\w+)(\s*\|\s*[^}]+)?\s*\}\}', self.command)


### PR DESCRIPTION
Besides the normal yaml template parameter wrapped by bracket, a valid parameter can also be manipulated by filters appended with dot `.` or functions appended with vertical bar `|`.

test the following template will generate command like `Running command: kubectl exec -n test-ns dnsutils -- nslookup kubernetes.default.svc.cluster.local`
```
      - name: "exec_on_dns_debug_pod"
        description: "Run a command inside the DNS debugging pod"
        command: "kubectl exec -n {{namespace|trim}} {{ pod_name }} -- {{ command.strip(\"'\") }}"
```
NOTE, `{{namespace|trim}}` has no practical use, and is for test only.

