### PR TITLE
chore: add issue template for bug and feature

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,31 @@
+name: Bug Report
+description: Report a bug encountered while operating holmesgpt
+labels: kind/bug
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: |
+        Please provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: How can we reproduce it (as minimally and precisely as possible)?
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else we need to know?

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -1,0 +1,20 @@
+name: Enhancement Tracking Issue
+description: Provide supporting details for a feature in development
+labels: kind/feature
+body:
+  - type: textarea
+    id: feature
+    attributes:
+      label: What would you like to be added?
+      description: |
+        Feature requests are unlikely to make progress as issues. Please consider engaging with SIGs on slack and mailing lists, instead.
+        A proposal that works through the design along with the implications of the change can be opened as a KEP.
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why is this needed?
+    validations:
+      required: true


### PR DESCRIPTION
To simplify the process of creating issues, we have added issue templates for bug and feature requests. The templates are basically copied from https://github.com/kubernetes/kubernetes/tree/master/.github/ISSUE_TEMPLATE but removed the items not related to homlesgpt. This is the initial attempt to add the template, and we can see how to add details into it to better describe a bug like introducing AI backend, and toolset type, and what local environment is necessary for us to debug the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a structured bug report template to streamline and improve bug submissions.
  - Added an enhancement tracking template for submitting and detailing feature requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->