### PR TITLE
Don't run Homebrew jobs for pre-releases

### DIFF
--- a/.github/workflows/build-binaries-and-brew.yaml
+++ b/.github/workflows/build-binaries-and-brew.yaml
@@ -164,6 +164,7 @@ jobs:
   update-formula:
     needs: [mac-hash, linux-hash]
     runs-on: ubuntu-latest
+    if: ${{ !github.event.release.prerelease }}
     steps:
       - name: Checkout homebrew-holmesgpt repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Fixes #448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow to skip formula update steps for prerelease versions, ensuring these steps only run for full releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->