### PR TITLE
Updating end-of-file-fixer to not run on image file types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
     hooks:
       - id: detect-private-key
       - id: end-of-file-fixer
+        exclude_types: [image]
       - id: trailing-whitespace
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.15.0


### PR DESCRIPTION
Fixes #461 
"image" type is defined in [pre-commit/identify](https://github.com/search?q=repo%3Apre-commit/identify%20%27image%27&type=code) repo

Did some testing locally 
![CleanShot 2025-05-29 at 08 47 27@2x](https://github.com/user-attachments/assets/e3fc6153-e444-48dd-a1c6-cdd5e4509d57)
