### PR TITLE
Allow overriding grafana healthcheck url

### DIFF
--- a/holmes/plugins/toolsets/grafana/common.py
+++ b/holmes/plugins/toolsets/grafana/common.py
@@ -19,6 +19,7 @@ class GrafanaConfig(BaseModel):
     url: str
     grafana_datasource_uid: Optional[str] = None
     external_url: Optional[str] = None
+    healthcheck: Optional[str] = "ready"
 
 
 def build_headers(api_key: Optional[str], additional_headers: Optional[Dict[str, str]]):

--- a/holmes/plugins/toolsets/grafana/grafana_api.py
+++ b/holmes/plugins/toolsets/grafana/grafana_api.py
@@ -21,7 +21,7 @@ def get_health(config: GrafanaConfig) -> Tuple[bool, str]:
         url = f"{config.url}/api/datasources/uid/{config.grafana_datasource_uid}/health"
     else:
         # Both loki and tempo provide the same /ready api
-        url = f"{config.url}/ready"
+        url = f"{config.url}/{config.healthcheck}"
 
     try:
         headers_ = build_headers(api_key=config.api_key, additional_headers=None)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to customize the health check endpoint for Grafana integrations via configuration.

- **Bug Fixes**
  - Improved flexibility of health check URL construction to support configurable endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->