### PR TITLE
fix(test): check classifier model pattern for Azure OpenAI

### DIFF
--- a/docs/evals-introduction.md
+++ b/docs/evals-introduction.md
@@ -133,7 +133,7 @@ Configure evaluations using these environment variables:
 | Variable | Example | Description |
 |----------|---------|-------------|
 | `MODEL` | `MODEL=anthropic/claude-3.5` | Specify which LLM model to use |
-| `CLASSIFIER_MODEL` | `CLASSIFIER_MODEL=gpt-4o` | The LLM model to use for scoring the answer (LLM as judge). Defaults to `MODEL` |
+| `CLASSIFIER_MODEL` | `CLASSIFIER_MODEL=gpt-4o` | The LLM model to use for scoring the answer (LLM as judge). Supported LLM providers are OpenAI and Azure OpenAI. Defaults to `MODEL` |
 | `ITERATIONS` | `ITERATIONS=3` | Run each test multiple times for consistency checking |
 | `RUN_LIVE` | `RUN_LIVE=true` | Execute `before-test` and `after-test` commands, ignore mock files |
 | `BRAINTRUST_API_KEY` | `BRAINTRUST_API_KEY=sk-1dh1...swdO02` | API key for Braintrust integration |

--- a/tests/llm/utils/classifiers.py
+++ b/tests/llm/utils/classifiers.py
@@ -1,8 +1,9 @@
+import os
 from typing import Dict, List, Optional, Union
+
+import openai
 from autoevals import LLMClassifier, init
 from braintrust.oai import wrap_openai
-import openai
-import os
 
 classifier_model = os.environ.get("CLASSIFIER_MODEL", os.environ.get("MODEL", "gpt-4o"))
 api_key = os.environ.get("AZURE_API_KEY", os.environ.get("OPENAI_API_KEY", None))
@@ -10,9 +11,13 @@ base_url = os.environ.get("AZURE_API_BASE", None)
 api_version = os.environ.get("AZURE_API_VERSION", None)
 
 if base_url:
+    if len(classifier_model.split("/")) != 2:
+        raise ValueError(
+            f"Current classifier model '{classifier_model}' does not meet the pattern 'azure/<deployment-name>' when using Azure OpenAI."
+        )
     client = openai.AzureOpenAI(
         azure_endpoint=base_url,
-        azure_deployment=classifier_model,
+        azure_deployment=classifier_model.split("/", 1)[1],
         api_version=api_version,
         api_key=api_key,
     )


### PR DESCRIPTION
By default, we want to share the llm model used for holmes and classifier, but the model used for Azure OpenAI follows the pattern azure/deployment-name, which cannot be passed to azure_deployment in `openai.AzureOpenAI`.
This PR extracts the deployment name from the model and validates the variable classifier_model follows the name pattern as MODEL