### PR TITLE
fix(toolset): access model fields via class

### DIFF
--- a/holmes/core/tools.py
+++ b/holmes/core/tools.py
@@ -343,7 +343,7 @@ class Toolset(BaseModel):
             exclude_unset=True,
             exclude=("name"),  # type: ignore
         ).items():
-            if field in self.model_fields and value not in (None, [], {}, ""):
+            if field in self.__class__.model_fields and value not in (None, [], {}, ""):
                 setattr(self, field, value)
 
     @model_validator(mode="before")


### PR DESCRIPTION
## PR Summary
This small PR updates the usage of field metadata access within the `Toolset` model to align with the Pydantic V2 API and resolve `PydanticDeprecatedSince211` warnings. Specifically:

- Replaced instance-level access `self.model_fields` with class-level `self.__class__.model_fields` in `holmes/core/tools.py`, as required by the Pydantic V2 convention for accessing model fields.

These changes ensure compatibility with Pydantic V2+ and address deprecation warnings related to `model_fields`, as seen in the [CI logs](https://github.com/robusta-dev/holmesgpt/actions/runs/15699252092/job/44230381330#step:5:75):
```python
/home/runner/work/holmesgpt/holmesgpt/holmes/core/tools.py:346: PydanticDeprecatedSince211: Accessing the 'model_fields' attribute on the instance is deprecated. Instead, you should access this attribute from the model class. Deprecated in Pydantic V2.11 to be removed in V3.0.
```
