### PR TITLE
Fix version warning from pipx

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,7 +69,7 @@ First [Pipx](https://github.com/pypa/pipx)
 Then install HolmesGPT from git:
 
 ```
-pipx install "https://github.com/robusta-dev/holmesgpt/archive/refs/heads/master.zip"
+pipx install --force "https://github.com/robusta-dev/holmesgpt/archive/refs/heads/master.zip"
 ```
 
 Verify that HolmesGPT was installed by checking the version:
@@ -87,7 +87,7 @@ holmes ask "what pods are unhealthy and why?"
 When new versions of HolmesGPT are released, you can upgrade HolmesGPT with pipx:
 
 ```
-pipx upgrade holmesgpt
+pipx install --force "https://github.com/robusta-dev/holmesgpt/archive/refs/heads/master.zip"
 ```
 
 ### From Source (Python Poetry)

--- a/holmes/__init__.py
+++ b/holmes/__init__.py
@@ -61,7 +61,7 @@ def get_version() -> str:
         try:
             with open(archival_file_path, "r") as f:
                 archival_data = json.load(f)
-                return f"{archival_data['refs']}-{archival_data['hash-short']}"
+                return f"dev-{archival_data['refs']}-{archival_data['hash-short']}"
         except Exception:
             pass
 

--- a/holmes/config.py
+++ b/holmes/config.py
@@ -115,11 +115,18 @@ class Config(RobustaBaseConfig):
 
     @property
     def is_latest_version(self) -> bool:
-        if self._holmes_info and self._holmes_info.latest_version and self._version:
-            return self._version.startswith(self._holmes_info.latest_version)
+        if (
+            not self._holmes_info
+            or not self._holmes_info.latest_version
+            or not self._version
+        ):
+            # We couldn't resolve version, assume we are running the latest version
+            return True
+        if self._version.startswith("dev-"):
+            # dev versions are considered to be the latest version
+            return True
 
-        # We couldn't resolve version, assume we are running the latest version
-        return True
+        return self._version.startswith(self._holmes_info.latest_version)
 
     @property
     def toolset_manager(self) -> ToolsetManager:
@@ -144,9 +151,7 @@ class Config(RobustaBaseConfig):
 
         if not self.is_latest_version and self._holmes_info:
             logging.warning(
-                "You are running version %s of holmes, but the latest version is %s. Please update to the latest version.",
-                self._version,
-                self._holmes_info.latest_version,
+                f"You are running version {self._version} of holmes, but the latest version is {self._holmes_info.latest_version}. Please update.",
             )
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "holmesgpt"
-version = "0.1.0"
+version = "0.0.0"
 description = ""
 authors = ["Natan Yellin <natan@robusta.dev>"]
 readme = "README.md"


### PR DESCRIPTION
Fixes #466 
Note: this is only a partial fix, as now holmes will disable version checks altogether when installed from a github source version.

I think this is OK, as once we push to pypi users will be instructed to install from pypi and the version check will work for them.