### PR TITLE
ROB-1457: issue with holmes not returning instructions

### DIFF
--- a/server.py
+++ b/server.py
@@ -157,7 +157,12 @@ def stream_investigate_issues(req: InvestigateRequest):
         )
         return StreamingResponse(
             ai.call_stream(
-                system_prompt, user_prompt, False, response_format, runbooks
+                system_prompt=system_prompt,
+                user_prompt=user_prompt,
+                stream=False,
+                response_format=response_format,
+                sections=sections,
+                runbooks=runbooks,
             ),
             media_type="text/event-stream",
         )


### PR DESCRIPTION
For RCA streaming, `runbooks` were passed as `sections` which means the actual runbooks were not returned in the answer.