### PR TITLE
fix: use correct prerequisites to check az cli login status

### DIFF
--- a/holmes/plugins/toolsets/aks-node-health.yaml
+++ b/holmes/plugins/toolsets/aks-node-health.yaml
@@ -4,7 +4,7 @@ toolsets:
     tags:
       - cli
     prerequisites:
-      - command: "az account list"
+      - command: "az account show"
       - command: "az aks --help"
       - command: "kubectl version --client"
     tools:

--- a/holmes/plugins/toolsets/aks.yaml
+++ b/holmes/plugins/toolsets/aks.yaml
@@ -4,7 +4,7 @@ toolsets:
     tags:
       - cli
     prerequisites:
-      - command: "az account list"
+      - command: "az account show"
       - command: "az aks --help"
       - command: "kubectl version --client"
     tools:


### PR DESCRIPTION
`az account list` does not return error when az cli does not log in to the Azure. Switch it to `az account show` to exit with error when azure login is done.