### PR TITLE
fix: runbook instruction should list all items clearly

### DIFF
--- a/holmes/config.py
+++ b/holmes/config.py
@@ -16,9 +16,11 @@ from holmes.core.llm import LLM, DefaultLLM
 from holmes.core.runbooks import RunbookManager
 from holmes.core.supabase_dal import SupabaseDal
 from holmes.core.tool_calling_llm import IssueInvestigator, ToolCallingLLM
+from holmes.core.tools_utils.tool_executor import ToolExecutor
 from holmes.core.toolset_manager import ToolsetManager
 from holmes.plugins.destinations.slack import SlackDestination
 from holmes.plugins.runbooks import (
+    RunbookCatalog,
     load_builtin_runbooks,
     load_runbook_catalog,
     load_runbooks_from_file,
@@ -32,7 +34,6 @@ from holmes.utils.definitions import RobustaConfig
 from holmes.utils.env import replace_env_vars_values
 from holmes.utils.file_utils import load_yaml_file
 from holmes.utils.pydantic_utils import RobustaBaseConfig, load_model_from_file
-from holmes.core.tools_utils.tool_executor import ToolExecutor
 
 DEFAULT_CONFIG_LOCATION = os.path.expanduser("~/.holmes/config.yaml")
 MODEL_LIST_FILE_LOCATION = os.environ.get(
@@ -243,14 +244,10 @@ class Config(RobustaBaseConfig):
         return None
 
     @staticmethod
-    def get_runbook_catalog() -> str:
+    def get_runbook_catalog() -> Optional[RunbookCatalog]:
         # TODO(mainred): besides the built-in runbooks, we need to allow the user to bring their own runbooks
         runbook_catalog = load_runbook_catalog()
-        if runbook_catalog is not None:
-            return runbook_catalog.model_dump_json()
-        else:
-            logging.warning("Runbook catalog not found")
-            return json.dumps({"catalog": []})
+        return runbook_catalog
 
     def create_console_tool_executor(self, dal: Optional[SupabaseDal]) -> ToolExecutor:
         """

--- a/holmes/plugins/prompts/_runbook_instructions.jinja2
+++ b/holmes/plugins/prompts/_runbook_instructions.jinja2
@@ -1,15 +1,11 @@
 {% if runbooks and runbooks.catalog|length > 0 %}
 # Runbook Selection
 
-# Available Runbooks
-
-{%- for runbook in runbooks.catalog -%}
-
-description: {{ runbook.description }}
+## Available Runbooks
+{% for runbook in runbooks.catalog %}
+### description: {{ runbook.description }}
 link: {{ runbook.link }}
-
-{%- endfor -%}
-
+{% endfor %}
 ALWAYS try to find the runbooks that can provide troubleshooting instructions when the user describes an operational issue, debugging scenario, or asks for step‑by‑step troubleshooting.
 To get the runbook details, use `fetch_runbook` tool by comparing the runbook description with the user prompt.
 ALWAYS follow the steps described in the runbook.

--- a/tests/plugins/prompt/test_generic_ask_conversation.py
+++ b/tests/plugins/prompt/test_generic_ask_conversation.py
@@ -38,4 +38,13 @@ def test_runbook_prompt():
     template = "builtin://generic_ask.jinja2"
     context = {"runbooks": load_runbook_catalog()}
     rendered = load_and_render_prompt(template, context)
-    assert "# Available Runbooks" in rendered
+    assert "## Available Runbooks" in rendered
+    assert "### description:" in rendered
+
+
+def test_runbook_empty_prompt():
+    template = "builtin://generic_ask.jinja2"
+    context = {"runbooks": None}
+    rendered = load_and_render_prompt(template, context)
+    assert "## Available Runbooks" not in rendered
+    assert "### description:" not in rendered


### PR DESCRIPTION
After the change, the _runbook_instructions.jinja2 is rendered as

```
# Runbook Selection\n\n## Available Runbooks\n\n### description: Runbook to investigate DNS resolution     
issue on Kubernetes cluster\nlink: networking/dns_troubleshooting_instructions.md\n\nALWAYS try to find the runbooks that can provide troubleshooting    
instructions when the user describes an operational issue, debugging scenario, or asks for step‑by‑step troubleshooting.\nTo get the runbook details, use
`fetch_runbook` tool by comparing the runbook description with the user prompt.\nALWAYS follow the steps described in the runbook.\nIf you decided not to
follow one or more steps, ALWAYS explain why.
```