### PR TITLE
Adding fix to encode utf8

### DIFF
--- a/holmes/plugins/prompts/__init__.py
+++ b/holmes/plugins/prompts/__init__.py
@@ -21,7 +21,7 @@ def load_prompt(prompt: str) -> str:
     else:
         return prompt
 
-    return open(path, encoding='utf-8').read()
+    return open(path, encoding="utf-8").read()
 
 
 def load_and_render_prompt(prompt: str, context: Optional[dict] = None) -> str:

--- a/holmes/plugins/prompts/__init__.py
+++ b/holmes/plugins/prompts/__init__.py
@@ -21,7 +21,7 @@ def load_prompt(prompt: str) -> str:
     else:
         return prompt
 
-    return open(path).read()
+    return open(path, encoding='utf-8').read()
 
 
 def load_and_render_prompt(prompt: str, context: Optional[dict] = None) -> str:


### PR DESCRIPTION
holmes ask fails on windows machines with the error shown below 


`holmes ask  "why are my nginx pods are unhealthy?" --model=azure/gpt-4o ╭───────────────────────────────────────── Traceback (most recent call last) ─────────────────────────────────────────╮ │ C:\Users\aritraghosh\pipx\venvs\holmesgpt\Lib\site-packages\holmes\main.py:341 in ask                               │ │                                                                                                                     │ │    338 │   │   slack_channel=slack_channel,                                                                         │ │    339 │   )                                                                                                        │ │    340 │                                                                                                            │ │ ❱  341 │   ai = config.create_console_toolcalling_llm(                                                              │ │    342 │   │   dal=None,  # type: ignore                                                                            │ │    343 │   )                                                                                                        │ │    344 │   template_context = {                                                                                     │ │                                                                                                                     │ │ C:\Users\aritraghosh\pipx\venvs\holmesgpt\Lib\site-packages\holmes\config.py:286 in create_console_toolcalling_llm  │ │                                                                                                                     │ │   283 │   def create_console_toolcalling_llm(                                                                       │ │   284 │   │   self, dal: Optional[SupabaseDal] = None                                                               │ │   285 │   ) -> ToolCallingLLM:                                                                                      │ │ ❱ 286 │   │   tool_executor = self.create_console_tool_executor(dal)                                                │ │   287 │   │   return ToolCallingLLM(tool_executor, self.max_steps, self._get_llm())                                 │ │   288 │                                                                                                             │ │   289 │   def create_toolcalling_llm(                                                                               │ │                                                                                                                     │ │ C:\Users\aritraghosh\pipx\venvs\holmesgpt\Lib\site-packages\holmes\config.py:262 in create_console_tool_executor    │ │                                                                                                                     │ │   259 │   │   2. toolsets from config file will override and be merged into built-in toolsets                       │ │   260 │   │   3. Custom toolsets from config files which can not override built-in toolsets                         │ │   261 │   │   """                                                                                                   │ │ ❱ 262 │   │   cli_toolsets = self.toolset_manager.list_console_toolsets(dal=dal)                                    │ │   263 │   │   return ToolExecutor(cli_toolsets)                                                                     │ │   264 │                                                                                                             │ │   265 │   def create_tool_executor(self, dal: Optional[SupabaseDal]) -> ToolExecutor:                               │ │                                                                                                                     │ │ C:\Users\aritraghosh\pipx\venvs\holmesgpt\Lib\site-packages\holmes\core\toolset_manager.py:287 in                   │ │ list_console_toolsets                                                                                               │ │                                                                                                                     │ │   284 │   │   listing console toolset does not refresh toolset status by default, and expects                       │ │   285 │   │   refreshed specifically and cached locally.                                                            │ │   286 │   │   """                                                                                                   │ │ ❱ 287 │   │   toolsets_with_status = self.load_toolset_with_status(                                                 │ │   288 │   │   │   dal,                                                                                              │ │   289 │   │   │   refresh_status=refresh_status,                                                                    │ │   290 │   │   │   enable_all_toolsets=True,                                                                         │ │                                                                                                                     │ │ C:\Users\aritraghosh\pipx\venvs\holmesgpt\Lib\site-packages\holmes\core\toolset_manager.py:230 in                   │ │ load_toolset_with_status                                                                                            │ │                                                                                                                     │ │   227 │   │   toolsets_status_by_name: dict[str, dict[str, Any]] = {                                                │ │   228 │   │   │   cached_toolset["name"]: cached_toolset for cached_toolset in cached_toolsets                      │ │   229 │   │   }                                                                                                     │ │ ❱ 230 │   │   all_toolsets_with_status = self._list_all_toolsets(                                                   │ │   231 │   │   │   dal=dal, check_prerequisites=False, toolset_tags=toolset_tags                                     │ │   232 │   │   )                                                                                                     │ │   233                                                                                                               │ │                                                                                                                     │ │ C:\Users\aritraghosh\pipx\venvs\holmesgpt\Lib\site-packages\holmes\core\toolset_manager.py:76 in _list_all_toolsets │ │                                                                                                                     │ │    73 │   │   3. custom toolset from config can override both built-in and add new custom tool                      │ │    74 │   │   """                                                                                                   │ │    75 │   │   # Load built-in toolsets                                                                              │ │ ❱  76 │   │   builtin_toolsets = load_builtin_toolsets(dal)                                                         │ │    77 │   │   toolsets_by_name: dict[str, Toolset] = {                                                              │ │    78 │   │   │   toolset.name: toolset for toolset in builtin_toolsets                                             │ │    79 │   │   }                                                                                                     │ │                                                                                                                     │ │ C:\Users\aritraghosh\pipx\venvs\holmesgpt\Lib\site-packages\holmes\plugins\toolsets\__init__.py:106 in              │ │ load_builtin_toolsets                                                                                               │ │                                                                                                                     │ │   103 │   │   toolsets_from_file = load_toolsets_from_file(path, strict_check=True)                                 │ │   104 │   │   all_toolsets.extend(toolsets_from_file)                                                               │ │   105 │                                                                                                             │ │ ❱ 106 │   all_toolsets.extend(load_python_toolsets(dal=dal))  # type: ignore                                        │ │   107 │                                                                                                             │ │   108 │   # disable built-in toolsets by default, and the user can enable them explicitly in c                      │ │   109 │   for toolset in all_toolsets:                                                                              │ │                                                                                                                     │ │ C:\Users\aritraghosh\pipx\venvs\holmesgpt\Lib\site-packages\holmes\plugins\toolsets\__init__.py:81 in               │ │ load_python_toolsets                                                                                                │ │                                                                                                                     │ │    78 │   │   BashExecutorToolset(),                                                                                │ │    79 │   │   MongoDBAtlasToolset(),                                                                                │ │    80 │   │   RunbookToolset(),                                                                                     │ │ ❱  81 │   │   AzureSQLToolset(),                                                                                    │ │    82 │   │   ServiceNowToolset(),                                                                                  │ │    83 │   ]                                                                                                         │ │    84 │   if not USE_LEGACY_KUBERNETES_LOGS:                                                                        │ │                                                                                                                     │ │ C:\Users\aritraghosh\pipx\venvs\holmesgpt\Lib\site-packages\holmes\plugins\toolsets\azure_sql\azure_sql_toolset.py: │ │ 77 in __init__                                                                                                      │ │                                                                                                                     │ │    74 │   │   │   │   AnalyzeConnectionFailures(self),                                                              │ │    75 │   │   │   ],                                                                                                │ │    76 │   │   )                                                                                                     │ │ ❱  77 │   │   self._reload_llm_instructions()                                                                       │ │    78 │                                                                                                             │ │    79 │   def prerequisites_callable(self, config: Dict[str, Any]) -> Tuple[bool, str]:                             │ │    80 │   │   if not config:                                                                                        │ │                                                                                                                     │ │ C:\Users\aritraghosh\pipx\venvs\holmesgpt\Lib\site-packages\holmes\plugins\toolsets\azure_sql\azure_sql_toolset.py: │ │ 183 in _reload_llm_instructions                                                                                     │ │                                                                                                                     │ │   180 │   │   template_file_path = os.path.abspath(                                                                 │ │   181 │   │   │   os.path.join(os.path.dirname(__file__), "azure_sql_instructions.jinja2")                          │ │   182 │   │   )                                                                                                     │ │ ❱ 183 │   │   self._load_llm_instructions(jinja_template=f"file://{template_file_path}")                            │ │   184                                                                                                               │ │                                                                                                                     │ │ C:\Users\aritraghosh\pipx\venvs\holmesgpt\Lib\site-packages\holmes\core\tools.py:467 in _load_llm_instructions      │ │                                                                                                                     │ │   464 │                                                                                                             │ │   465 │   def _load_llm_instructions(self, jinja_template: str):                                                    │ │   466 │   │   tool_names = [t.name for t in self.tools]                                                             │ │ ❱ 467 │   │   self.llm_instructions = load_and_render_prompt(                                                       │ │   468 │   │   │   prompt=jinja_template,                                                                            │ │   469 │   │   │   context={"tool_names": tool_names, "config": self.config},                                        │ │   470 │   │   )                                                                                                     │ │                                                                                                                     │ │ C:\Users\aritraghosh\pipx\venvs\holmesgpt\Lib\site-packages\holmes\plugins\prompts\__init__.py:34 in                │ │ load_and_render_prompt                                                                                              │ │                                                                                                                     │ │   31 │                                                                                                              │ │   32 │   context is a dictionary of variables to be passed to the jinja2 template                                   │ │   33 │   """                                                                                                        │ │ ❱ 34 │   prompt_as_str = load_prompt(prompt)                                                                        │ │   35 │                                                                                                              │ │   36 │   env = Environment(                                                                                         │ │   37 │   │   loader=FileSystemLoader(THIS_DIR),                                                                     │ │                                                                                                                     │ │ C:\Users\aritraghosh\pipx\venvs\holmesgpt\Lib\site-packages\holmes\plugins\prompts\__init__.py:24 in load_prompt    │ │                                                                                                                     │ │   21 │   else:                                                                                                      │ │   22 │   │   return prompt                                                                                          │ │   23 │                                                                                                              │ │ ❱ 24 │   return open(path).read()                                                                                   │ │   25                                                                                                                │ │   26                                                                                                                │ │   27 def load_and_render_prompt(prompt: str, context: Optional[dict] = None) -> str:                                │ │                                                                                                                     │ │ C:\Program                                                                                                          │ │ Files\WindowsApps\PythonSoftwareFoundation.Python.3.11_3.11.2544.0_x64__qbz5n2kfra8p0\Lib\encodings\cp1252.py:23 in │ │ decode                                                                                                              │ │                                                                                                                     │ │    20                                                                                                               │ │    21 class IncrementalDecoder(codecs.IncrementalDecoder):                                                          │ │    22 │   def decode(self, input, final=False):                                                                     │ │ ❱  23 │   │   return codecs.charmap_decode(input,self.errors,decoding_table)[0]                                     │ │    24                                                                                                               │ │    25 class StreamWriter(Codec,codecs.StreamWriter):                                                                │ │    26 │   pass                                                                                                      │ ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 3264: character maps to <undefined>`