### PR TITLE
Fix 'G' key behavior in /show command to go to beginning of last line

### DIFF
--- a/holmes/interactive.py
+++ b/holmes/interactive.py
@@ -309,7 +309,11 @@ def show_tool_output_modal(tool_call: ToolCallResult, console: Console) -> None:
         @bindings.add("end")
         def _(event):
             event.app.layout.focus(text_area)
+            # Go to last line, then to beginning of that line
             text_area.buffer.cursor_position = len(text_area.buffer.text)
+            text_area.buffer.cursor_left(
+                count=text_area.buffer.document.cursor_position_col
+            )
 
         @bindings.add("d")
         @bindings.add("c-d")


### PR DESCRIPTION

Previously, pressing 'G' in the /show modal would position the cursor at the end of the last line, causing UI confusion. This fix implements proper vim-like behavior where 'G' moves to the beginning of the last line by:
1. Moving to the end of all text
2. Using cursor_left with cursor_position_col to move back to line start