### PR TITLE
Update build-and-deploy-docs.yaml

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yaml
+++ b/.github/workflows/build-and-deploy-docs.yaml
@@ -16,7 +16,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: "3.11"
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
Docs are failing because GitHub actions used Python version 3.13.5. But module was removed in version Python 3.12 ([details](https://docs.python.org/3/library/distutils.html)). 
```
Error output:
Traceback (most recent call last):
  File "<stdin>", line 9, in <module>
ModuleNotFoundError: No module named 'distutils'
```

Tested this fix on my account here https://github.com/pavangudiwada/holmesgpt/actions/runs/16450522228/job/46494249324
Here's the change https://github.com/pavangudiwada/holmesgpt/blob/7e20ddf4f188ec2204265de5406463b8434864f4/.github/workflows/build-and-deploy-docs.yaml#L19