### PR TITLE
Add timeout to kafka prerequisites check

### DIFF
--- a/holmes/plugins/toolsets/kafka.py
+++ b/holmes/plugins/toolsets/kafka.py
@@ -591,6 +591,9 @@ class KafkaToolset(Toolset):
                     admin_config = {
                         "bootstrap.servers": cluster.kafka_broker,
                         "client.id": cluster.kafka_client_id,
+                        "socket.timeout.ms": 15000,  # 15 second timeout
+                        "metadata.request.timeout.ms": 15000,  # 15 second metadata timeout
+                        "api.version.request.timeout.ms": 15000,  # 15 second API version timeout
                     }
 
                     if cluster.kafka_security_protocol:
@@ -604,6 +607,11 @@ class KafkaToolset(Toolset):
                         admin_config["sasl.password"] = cluster.kafka_password
 
                     client = AdminClient(admin_config)
+                    # Test the connection by trying to list topics with a timeout
+                    # This will fail fast if the broker is not reachable
+                    future = client.list_topics(timeout=15)  # 15 second timeout
+                    if future is None:
+                        raise Exception("Failed to connect to Kafka broker")
                     self.clients[cluster.name] = client  # Store in dictionary
                 except Exception as e:
                     message = (


### PR DESCRIPTION
Without the timeout it was causing the test framework to hang forever when kafka does not exist.