### PR TITLE
Add right information for investigate evals

### DIFF
--- a/holmes/core/investigation.py
+++ b/holmes/core/investigation.py
@@ -24,6 +24,7 @@ def investigate_issues(
     dal: SupabaseDal,
     config: Config,
     model: Optional[str] = None,
+    trace_span=None,
 ) -> InvestigationResult:
     load_robusta_api_key(dal=dal, config=config)
     context = dal.get_issue_data(investigate_request.context.get("robusta_issue_id"))
@@ -54,6 +55,7 @@ def investigate_issues(
         instructions=resource_instructions,
         global_instructions=global_instructions,
         sections=investigate_request.sections,
+        trace_span=trace_span,
     )
 
     (text_response, sections) = process_response_into_sections(investigation.result)

--- a/holmes/core/investigation.py
+++ b/holmes/core/investigation.py
@@ -7,6 +7,7 @@ from holmes.core.investigation_structured_output import process_response_into_se
 from holmes.core.issue import Issue
 from holmes.core.models import InvestigateRequest, InvestigationResult
 from holmes.core.supabase_dal import SupabaseDal
+from holmes.core.tracing import DummySpan, SpanType
 from holmes.utils.global_instructions import add_global_instructions_to_user_prompt
 from holmes.utils.robusta import load_robusta_api_key
 
@@ -24,7 +25,7 @@ def investigate_issues(
     dal: SupabaseDal,
     config: Config,
     model: Optional[str] = None,
-    trace_span=None,
+    trace_span=DummySpan(),
 ) -> InvestigationResult:
     load_robusta_api_key(dal=dal, config=config)
     context = dal.get_issue_data(investigate_request.context.get("robusta_issue_id"))
@@ -38,7 +39,12 @@ def investigate_issues(
     if context:
         raw_data["extra_context"] = context
 
+    # If config is not preinitilized
+    create_issue_investigator_span = trace_span.start_span(
+        "create_issue_investigator", SpanType.FUNCTION.value
+    )
     ai = config.create_issue_investigator(dal=dal, model=model)
+    create_issue_investigator_span.end()
 
     issue = Issue(
         id=context["id"] if context else "",

--- a/holmes/core/tool_calling_llm.py
+++ b/holmes/core/tool_calling_llm.py
@@ -221,6 +221,7 @@ class ToolCallingLLM:
         post_process_prompt: Optional[str] = None,
         response_format: Optional[Union[dict, Type[BaseModel]]] = None,
         sections: Optional[InputSectionsDataType] = None,
+        trace_span=DummySpan(),
     ) -> LLMResult:
         messages = [
             {"role": "system", "content": system_prompt},
@@ -232,6 +233,7 @@ class ToolCallingLLM:
             response_format,
             user_prompt=user_prompt,
             sections=sections,
+            trace_span=trace_span,
         )
 
     def messages_call(
@@ -782,6 +784,7 @@ class IssueInvestigator(ToolCallingLLM):
         global_instructions: Optional[Instructions] = None,
         post_processing_prompt: Optional[str] = None,
         sections: Optional[InputSectionsDataType] = None,
+        trace_span=DummySpan(),
     ) -> LLMResult:
         runbooks = self.runbook_manager.get_instructions_for_issue(issue)
 
@@ -865,6 +868,7 @@ class IssueInvestigator(ToolCallingLLM):
             post_processing_prompt,
             response_format=response_format,
             sections=sections,
+            trace_span=trace_span,
         )
         res.instructions = runbooks
         return res

--- a/holmes/core/tracing.py
+++ b/holmes/core/tracing.py
@@ -91,10 +91,11 @@ class SpanType(Enum):
     """Standard span types for tracing categorization."""
 
     LLM = "llm"
-    TOOL = "tool"
-    TASK = "task"
     SCORE = "score"
+    FUNCTION = "function"
     EVAL = "eval"
+    TASK = "task"
+    TOOL = "tool"
 
 
 class DummySpan:

--- a/tests/llm/test_investigate.py
+++ b/tests/llm/test_investigate.py
@@ -1,5 +1,6 @@
 # type: ignore
 import os
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -138,12 +139,15 @@ def test_investigate(
                 with eval_span.start_span(
                     "Holmes", type=SpanType.TASK.value
                 ) as holmes_span:
+                    start_time = time.time()
                     result = investigate_issues(
                         investigate_request=investigate_request,
                         config=config,
                         dal=mock_dal,
                         trace_span=holmes_span,
                     )
+                    holmes_duration = time.time() - start_time
+                eval_span.log(metadata={"Holmes Duration": holmes_duration})
     assert result, "No result returned by investigate_issues()"
 
     output = result.analysis

--- a/tests/llm/test_investigate.py
+++ b/tests/llm/test_investigate.py
@@ -128,11 +128,12 @@ def test_investigate(
                 )
 
             with set_test_env_vars(test_case):
-                with eval_span.start_span("Holmes Run", type=SpanType.LLM):
+                with eval_span.start_span("Holmes Run", type=SpanType.LLM) as llm_span:
                     result = investigate_issues(
                         investigate_request=investigate_request,
                         config=config,
                         dal=mock_dal,
+                        trace_span=llm_span,
                     )
     assert result, "No result returned by investigate_issues()"
 

--- a/tests/llm/test_investigate.py
+++ b/tests/llm/test_investigate.py
@@ -128,7 +128,9 @@ def test_investigate(
                 )
 
             with set_test_env_vars(test_case):
-                with eval_span.start_span("Holmes Run", type=SpanType.LLM) as llm_span:
+                with tracer.start_trace(
+                    "run holmes", span_type=SpanType.LLM
+                ) as llm_span:
                     result = investigate_issues(
                         investigate_request=investigate_request,
                         config=config,


### PR DESCRIPTION
- Tool call results now show up
- Fixed a bug that caused LLM duration to be doubled 
- Pre-starting the tools executor so it is not counted as a part of Holmes' duration
- Add a metadata fields for Holmes Duration for display in braintrust (does not support aggregate though)
