### PR TITLE
replace pwd with os compatible getpass

### DIFF
--- a/holmes/core/tracing.py
+++ b/holmes/core/tracing.py
@@ -1,12 +1,12 @@
-import os
+import getpass
 import logging
+import os
 import platform
-import pwd
 import socket
 from datetime import datetime
-from typing import Optional, Any, Union, Dict
-from pathlib import Path
 from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
 
 BRAINTRUST_API_KEY = os.environ.get("BRAINTRUST_API_KEY")
 BRAINTRUST_ORG = os.environ.get("BRAINTRUST_ORG", "robustadev")
@@ -69,7 +69,7 @@ def get_active_branch_name():
 
 def get_machine_state_tags() -> Dict[str, str]:
     return {
-        "username": pwd.getpwuid(os.getuid()).pw_name,
+        "username": getpass.getuser(),
         "branch": get_active_branch_name(),
         "platform": platform.platform(),
         "hostname": socket.gethostname(),


### PR DESCRIPTION
1. pwd module (Unix/Linux only) in holmes/core/tracing.py

import pwd
"username": pwd.getpwuid(os.getuid()).pw_name,

2. signal in tests/llm/utils/port_forward.py
```
import signal
os.killpg(os.getpgid(self.process.pid), signal.SIGTERM)
os.killpg(os.getpgid(self.process.pid), signal.SIGKILL)
```
We can ignore this as it's test

3. hard-coded unix paths in holmes/common/env_vars.py

"ROBUSTA_CONFIG_PATH", "/etc/robusta/config/active_playbooks.yaml"

Currently it's used in server side, and can be fixed by overwriting the path