### PR TITLE
Update test_case.yaml

### DIFF
--- a/tests/llm/fixtures/test_ask_holmes/01_how_many_pods/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/01_how_many_pods/test_case.yaml
@@ -1,6 +1,6 @@
-user_prompt: "How many pods are running in the test-1 namespace?"
+user_prompt: "How many pods are in the test-1 namespace?"
 expected_output:
-  - 14 pods are running in the test-1 namespace
+  - There are 14 pods in the test-1 namespace
 before_test: |
   kubectl apply -f manifests.yaml
   sleep 60


### PR DESCRIPTION
Pods have a default "running" state. So if the LLM filters on the "running" pods, the answer will be 2. 