### PR TITLE
Improve datadog evals

### DIFF
--- a/tests/llm/fixtures/test_ask_holmes/110_cpu_graph_robusta_runner/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/110_cpu_graph_robusta_runner/test_case.yaml
@@ -21,6 +21,6 @@ expected_output: |
   Output must contain 1 or more embeds in the following format
     <<{"type": "datadogql", "tool_name": "query_datadog_metrics", "random_key": "iD8G"}>>
 
-  random_key may be different than the above example, but all other parameters (type and tool_name) must be as described
+  random_key may be different than the above example so long as its a random looking key, but all other parameters (type and tool_name) must be as described
 
   Output must NOT tell the user it doesn't have access to metrics or that they should use another tool

--- a/tests/llm/fixtures/test_ask_holmes/91_cpu_graph_robusta_runner/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/91_cpu_graph_robusta_runner/test_case.yaml
@@ -13,7 +13,7 @@ expected_output: |
   Output must contain 1 or more embeds in the following format
     <<{"type": "datadogql", "tool_name": "query_datadog_metrics", "random_key": "iD8G"}>>
 
-  random_key may be different than the above example, but all other parameters (type and tool_name) must be as described
+  random_key may be different than the above example so long as its a random looking key, but all other parameters (type and tool_name) must be as described
 
   Output must NOT tell the user it doesn't have access to metrics or that they should use another tool
 

--- a/tests/llm/fixtures/test_ask_holmes/92_cpu_graph_conversation/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/92_cpu_graph_conversation/test_case.yaml
@@ -13,7 +13,7 @@ expected_output: |
   Output must contain 1 or more embeds in the following format
     <<{"type": "datadogql", "tool_name": "query_datadog_metrics", "random_key": "iD8G"}>>
 
-  random_key may be different than the above example, but all other parameters (type and tool_name) must be as described
+  random_key may be different than the above example so long as its a random looking key, but all other parameters (type and tool_name) must be as described
 
   Output must NOT tell the user it doesn't have access to metrics or that they should use another tool
 

--- a/tests/llm/fixtures/test_ask_holmes/93_calling_datadog/fetch_pod_logssock-shop_catalogue-db-c948fd796-w4vzl_-3600.txt
+++ b/tests/llm/fixtures/test_ask_holmes/93_calling_datadog/fetch_pod_logssock-shop_catalogue-db-c948fd796-w4vzl_-3600.txt
@@ -1,2 +1,2 @@
-{"toolset_name":"datadog/logs","tool_name":"fetch_pod_logs","match_params":{"pod_name":"catalogue-db-c948fd796-w4vzl","namespace":"sock-shop","start_time":"-3600"}}
+{"toolset_name":"datadog/logs","tool_name":"fetch_pod_logs","match_params":{"pod_name":"catalogue-db-c948fd796-w4vzl","namespace":"sock-shop"}}
 {"schema_version": "robusta:v1.0.0", "status": "no_data", "error": null, "return_code": null, "url": null, "invocation": null, "params": {"namespace": "sock-shop", "pod_name": "catalogue-db-c948fd796-w4vzl", "start_time": "-3600", "end_time": null, "filter": null, "limit": null}}

--- a/tests/llm/fixtures/test_ask_holmes/93_calling_datadog/fetch_pod_logssock-shop_catalogue-f7687cb4-zsngc_-3600.txt
+++ b/tests/llm/fixtures/test_ask_holmes/93_calling_datadog/fetch_pod_logssock-shop_catalogue-f7687cb4-zsngc_-3600.txt
@@ -1,4 +1,4 @@
-{"toolset_name":"datadog/logs","tool_name":"fetch_pod_logs","match_params":{"pod_name":"catalogue-f7687cb4-zsngc","namespace":"sock-shop","start_time":"-3600"}}
+{"toolset_name":"datadog/logs","tool_name":"fetch_pod_logs","match_params":{"pod_name":"catalogue-f7687cb4-zsngc","namespace":"sock-shop"}}
 {"schema_version": "robusta:v1.0.0", "status": "success", "error": null, "return_code": null, "url": null, "invocation": null, "params": {"namespace": "sock-shop", "pod_name": "catalogue-f7687cb4-zsngc", "start_time": "-3600", "end_time": null, "filter": null, "limit": null}}
 ts=2025-08-04T11:51:00Z caller=logging.go:85 method=Health result=2 took=40µs
 ts=2025-08-04T11:51:00Z caller=logging.go:85 method=Health result=2 took=25.103µs


### PR DESCRIPTION
Two fixes for datadog evals:

1. Make several datadog metric evals **stricter** so that the following does not pass!

<img width="1111" height="570" alt="Screenshot 2025-08-11 at 16 47 31" src="https://github.com/user-attachments/assets/a6d26cb7-1979-4ac8-a800-b34743a0ac65" />

2. Loosen the requirements around mock_data in eval 93 so it works even when the llm modifies the default time frame (or leaves it out altogether)