### PR TITLE
Docs: update mkdocs port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,12 @@ test-llm-ask-holmes:
 
 test-without-llm:
 	poetry run pytest tests -m "not llm"
+
+docs:
+	poetry run mkdocs serve --dev-addr=127.0.0.1:7000
+
+docs-build:
+	poetry run mkdocs build
+
+docs-strict:
+	poetry run mkdocs serve --dev-addr=127.0.0.1:7000 --strict

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,14 +22,14 @@ poetry install --with=dev
 To serve the documentation locally with live reload:
 
 ```bash
-# From the repository root
-poetry run mkdocs serve
+# From the repository root (serves on http://127.0.0.1:7000)
+poetry run mkdocs serve --dev-addr=127.0.0.1:7000
 
 # Or specify a different port
 poetry run mkdocs serve --dev-addr=127.0.0.1:8001
 ```
 
-The documentation will be available at `http://127.0.0.1:8000` (or the port you specified).
+The documentation will be available at `http://127.0.0.1:7000` (or the port you specified).
 
 ### Build Static Site
 


### PR DESCRIPTION
I'm choosing a port less likely to conflict with other tooling commonly deployed