### PR TITLE
Add custom query parameter support to FetchDatadogTracesList for enhanced search flexibility

### DIFF
--- a/holmes/plugins/toolsets/datadog/toolset_datadog_traces.py
+++ b/holmes/plugins/toolsets/datadog/toolset_datadog_traces.py
@@ -159,6 +159,11 @@ class FetchDatadogTracesList(BaseDatadogTracesTool):
             name="fetch_datadog_traces",
             description="Fetch a list of traces from Datadog with optional filters",
             parameters={
+                "query": ToolParameter(
+                    description="Datadog search query (e.g., 'service:web-app @http.status_code:500')",
+                    type="string",
+                    required=False,
+                ),
                 "service": ToolParameter(
                     description="Filter by service name",
                     type="string",
@@ -200,6 +205,9 @@ class FetchDatadogTracesList(BaseDatadogTracesTool):
 
     def get_parameterized_one_liner(self, params: dict) -> str:
         """Get a one-liner description of the tool invocation."""
+        if "query" in params:
+            return f"{toolset_name_for_one_liner(self.toolset.name)}: Fetch Traces ({params['query']})"
+
         filters = []
         if "service" in params:
             filters.append(f"service={params['service']}")
@@ -238,6 +246,11 @@ class FetchDatadogTracesList(BaseDatadogTracesTool):
             # Build search query
             query_parts = []
 
+            # If a custom query is provided, use it as the base
+            if params.get("query"):
+                query_parts.append(params["query"])
+
+            # Add additional filters
             if params.get("service"):
                 query_parts.append(f"service:{params['service']}")
 


### PR DESCRIPTION
**Add custom query parameter support to FetchDatadogTracesList for enhanced search flexibility**

### Description ###
This change adds support for custom Datadog queries in the FetchDatadogTracesList tool, bringing it in line with the existing FetchDatadogSpansByFilter functionality.

### Benefits ### 

1. Enhanced flexibility: Users can now use native Datadog query syntax directly (e.g., service:web-app @http.status_code:500)
2. Consistency: Aligns behavior between traces and spans tools within the toolset
3. Advanced filtering: Enables complex search patterns not available through individual parameters alone
4. Backward compatibility: Maintains full compatibility with existing individual parameters (service, operation, resource, etc.)

### Changes implemented ### 

- Added optional query parameter to FetchDatadogTracesList tool
- Modified _invoke method to process custom queries as the base search filter
- Updated get_parameterized_one_liner to display the query when provided
- Custom queries are combined with specific filters when both are provided

This enhancement significantly improves the usability of the Datadog traces toolset by enabling more sophisticated and precise trace searches.