### PR TITLE
Add comprehensive .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,121 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Poetry
+poetry.lock
+
+# Testing
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Documentation
+docs/
+docs/_build/
+.sphinx-build/
+*.md
+README*
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Logs
+*.log
+logs/
+
+# Temporary files
+tmp/
+temp/
+
+# Configuration & Secrets
+.env*
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+*.key
+*.pem
+*.crt
+secrets/
+credentials/
+
+# API Keys & Claude Instructions
+CLAUDE.md
+CLAUDE.local.md
+CLAUDE*.md
+*_API_KEY*
+*api_key*
+*_TOKEN*
+*token*
+.secrets
+config.yaml
+~/.holmes/config.yaml
+
+# Common mistakes
+.vscode/settings.json
+.idea/workspace.xml
+*.backup
+*.bak
+*.orig
+*.tmp
+*~
+.DS_Store
+
+# Node modules (if any)
+node_modules/
+
+# Holmes specific
+~/.holmes/
+.holmes/


### PR DESCRIPTION
Excludes development files, secrets, API keys, documentation, and common temporary files from Docker builds to reduce image size and prevent accidental inclusion of sensitive information.