### PR TITLE
add --fast flag

### DIFF
--- a/holmes/core/prompt.py
+++ b/holmes/core/prompt.py
@@ -54,6 +54,9 @@ def build_initial_ask_messages(
         runbooks: Optional runbook catalog
         system_prompt_additions: Optional additional system prompt content
     """
+    # Check if todos are enabled by looking for core_investigation toolset
+    has_todos = any(ts.name == "core_investigation" for ts in tool_executor.toolsets)
+
     # Load and render system prompt internally
     system_prompt_template = "builtin://generic_ask.jinja2"
     template_context = {
@@ -61,6 +64,7 @@ def build_initial_ask_messages(
         "runbooks": runbooks or {},
         "system_prompt_additions": system_prompt_additions or "",
         "investigation_id": investigation_id,
+        "has_todos": has_todos,
     }
     system_prompt_rendered = load_and_render_prompt(
         system_prompt_template, template_context

--- a/holmes/main.py
+++ b/holmes/main.py
@@ -215,6 +215,11 @@ def ask(
         "--system-prompt-additions",
         help="Additional content to append to the system prompt",
     ),
+    fast: bool = typer.Option(
+        False,
+        "--fast",
+        help="Fast mode: disables todos tool for quicker responses",
+    ),
 ):
     """
     Ask any question and answer using available tools
@@ -252,6 +257,7 @@ def ask(
         dal=None,  # type: ignore
         refresh_toolsets=refresh_toolsets,  # flag to refresh the toolset status
         tracer=tracer,
+        disable_todos=fast,  # disable todos tool when --fast is used
     )
 
     if prompt_file and prompt:

--- a/holmes/plugins/prompts/_general_instructions.jinja2
+++ b/holmes/plugins/prompts/_general_instructions.jinja2
@@ -51,6 +51,7 @@
 * For any question, try to make the answer specific to the user's cluster.
 ** For example, if asked to port forward, find out the app or pod port (kubectl describe) and provide a port forward command specific to the user's question
 
+{% if has_todos %}
 # MANDATORY Task Management
 
 * You MUST use the TodoWrite tool for ANY investigation requiring multiple steps
@@ -62,6 +63,7 @@
 * Follow ALL tasks in your plan - don't skip any tasks
 * Use task management to ensure you don't miss important investigation steps
 * If you discover additional steps during investigation, add them to your task list using TodoWrite
+{% endif %}
 
 # Tool/function calls
 


### PR DESCRIPTION
I'm not crazy about this implementation. I would much rather has the --fast flag enable/disable the ToDo toolset and have everything else happen automatically. i.e. if each toolset had an API like 'add_to_system_prompt' then we could just disable the toolset and automatically nothing would be added to the prompt. 