### PR TITLE
[ROB-1923] - added amp holmes irsa support

### DIFF
--- a/holmes/plugins/toolsets/prometheus/prometheus.py
+++ b/holmes/plugins/toolsets/prometheus/prometheus.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import boto3
 import os
 import re
 import time
@@ -86,22 +87,53 @@ class PrometheusConfig(BaseModel):
 
 
 class AMPConfig(PrometheusConfig):
-    aws_access_key: str
-    aws_secret_access_key: str
+    aws_access_key: Optional[str] = None
+    aws_secret_access_key: Optional[str] = None
     aws_region: str
     aws_service_name: str = "aps"
-    healthcheck: str = "api/v1/query?query=up"  # Override for AMP
-    prometheus_ssl_enabled: bool = False
+    healthcheck: str = "api/v1/query?query=up"
+    prometheus_ssl_enabled: bool = True
 
     def is_amp(self) -> bool:
         return True
 
-    def get_auth(self):
+    def _build_irsa_auth(self) -> Optional[AWS4Auth]:
+        """Try IRSA (or default AWS provider chain)."""
+        session = boto3.Session()
+        creds = session.get_credentials()
+        if creds is None:
+            return None
+        frozen = creds.get_frozen_credentials()
         return AWS4Auth(
-            self.aws_access_key,  # type: ignore
-            self.aws_secret_access_key,  # type: ignore
-            self.aws_region,  # type: ignore
-            self.aws_service_name,  # type: ignore
+            frozen.access_key,
+            frozen.secret_key,
+            self.aws_region,
+            self.aws_service_name,
+            session_token=frozen.token,
+        )
+
+    def _build_static_auth(self) -> Optional[AWS4Auth]:
+        """Fallback: static credentials from config."""
+        if self.aws_access_key and self.aws_secret_access_key:
+            return AWS4Auth(
+                self.aws_access_key,
+                self.aws_secret_access_key,
+                self.aws_region,
+                self.aws_service_name,
+            )
+        return None
+
+    def get_auth(self):
+        # Prefer IRSA, fallback to static
+        irsa_auth = self._build_irsa_auth()
+        if irsa_auth:
+            return irsa_auth
+        static_auth = self._build_static_auth()
+        if static_auth:
+            return static_auth
+        raise RuntimeError(
+            "No AWS credentials available. Tried IRSA and static keys. "
+            "Ensure IRSA is configured on the service account or provide aws_access_key/aws_secret_access_key."
         )
 
 
@@ -847,10 +879,8 @@ class PrometheusToolset(Toolset):
     def determine_prometheus_class(
         self, config: dict[str, Any]
     ) -> Type[Union[PrometheusConfig, AMPConfig]]:
-        has_aws_credentials = (
-            "aws_access_key" in config or "aws_secret_access_key" in config
-        )
-        return AMPConfig if has_aws_credentials else PrometheusConfig
+        has_aws_fields = "aws_region" in config
+        return AMPConfig if has_aws_fields else PrometheusConfig
 
     def prerequisites_callable(self, config: dict[str, Any]) -> Tuple[bool, str]:
         try:


### PR DESCRIPTION
Verified backwards compatibility with keys also
```
holmes:
  serviceAccount:
    annotations:
      eks.amazonaws.com/role-arn: arn:aws:iam::...:role/amp-iamproxy-ingest-role_name_here
  toolsets:
    prometheus/metrics:
      config:
        prometheus_url: ...
        aws_region: us-east-2
        aws_service_name: aps
        prometheus_ssl_enabled: true
        additional_labels:
          cluster: my-cluster-label
      enabled: true
```