### PR TITLE
feat: adding option for creating extra kubernetes resource

### DIFF
--- a/helm/holmes/templates/extra-objects.yaml
+++ b/helm/holmes/templates/extra-objects.yaml
@@ -1,0 +1,8 @@
+{{ range .Values.extraObjects }}
+---
+{{ if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
+{{ end }}


### PR DESCRIPTION
Allowing users to add extra kubernetes resouces without the need to fork the helm chart internally. 

Example scenarios:
1. external secrets
2. Istio virtual services

