### PR TITLE
don't trigger build on push non-master branch

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,4 +1,4 @@
-# this runs on every commit/PR to test that we are properly building binaries that work
+# This runs on every commit/PR to test that we are properly building binaries that work
 # we test this on each commit/PR to catch build problems early
 name: Build and test HolmesGPT
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -2,7 +2,12 @@
 # we test this on each commit/PR to catch build problems early
 name: Build and test HolmesGPT
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   check:


### PR DESCRIPTION
Pull requests triggers duplicated builds for both push and pull_request. Limit the push event to master only to not trigger a redundant build.

<img width="938" height="244" alt="image" src="https://github.com/user-attachments/assets/79ccbe1d-c09d-4e20-ab96-c6043416a0d9" />
