### PR TITLE
Don't fail the evals workflow on regressions

### DIFF
--- a/.github/workflows/llm-evaluation.yaml
+++ b/.github/workflows/llm-evaluation.yaml
@@ -171,13 +171,3 @@ jobs:
             } catch(e) {
               console.log(e)
             }
-      - name: Check test results
-        if: always()
-        run: |
-          if [[ -f "regressions.txt" ]]; then
-            echo "There are regressions in the evals. Please check the evals file for details."
-            cat regressions.txt
-            exit 1
-          else
-            echo "All tests passed without regressions."
-          fi


### PR DESCRIPTION
Right now a failed eval spams your inbox. I don't think we need to fail the github workflow when there are regressions. We're already posting the report and you should review it before merging.