### PR TITLE
Small eval improvements + investigation-refusal eval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,8 @@ markers = [
     "traces: Tests where the ai is expected to find the solution using the traces",
     "answer-given-wrong-place: LLM gave the answer in intermediate steps, not final answer, so its harder for the user to see the answer",
     "datadog: DataDog toolset",
-    "storage: Disk related, like I/O or disk space"
+    "storage: Disk related, like I/O or disk space",
+    "prometheus: Tests involving Prometheus metrics"
 ]
 
 addopts = [

--- a/tests/llm/fixtures/test_ask_holmes/151_disabled_toolsets_fallback_only/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/151_disabled_toolsets_fallback_only/test_case.yaml
@@ -1,7 +1,6 @@
 description: Tests if Holmes first tries to use available tools to investigate before falling back to suggesting enabling new tools
 user_prompt: "Our Kafka cluster is experiencing high consumer lag. Can you investigate?"
-expected_output:
-  "Result must include a tool call to Prometheus"
+expected_output: "Result must include a tool call to Prometheus"
 tags:
   - transparency
   - prometheus

--- a/tests/llm/fixtures/test_ask_holmes/151_disabled_toolsets_fallback_only/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/151_disabled_toolsets_fallback_only/test_case.yaml
@@ -1,0 +1,13 @@
+description: Tests if Holmes first tries to use available tools to investigate before falling back to suggesting enabling new tools
+user_prompt: "Our Kafka cluster is experiencing high consumer lag. Can you investigate?"
+expected_output:
+  "Result must include a tool call to Prometheus"
+tags:
+  - transparency
+  - prometheus
+include_tool_calls: true
+port_forwards:
+  - namespace: default
+    service: robusta-kube-prometheus-st-prometheus
+    local_port: 9090
+    remote_port: 9090

--- a/tests/llm/fixtures/test_ask_holmes/151_disabled_toolsets_fallback_only/toolsets.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/151_disabled_toolsets_fallback_only/toolsets.yaml
@@ -1,0 +1,12 @@
+toolsets:
+  # Keep Prometheus enabled but disable Kafka toolset
+  prometheus/metrics:
+    enabled: true
+    config:
+      prometheus_url: http://localhost:9090
+  kafka/admin:
+    enabled: false
+  kubernetes/core:
+    enabled: true
+  kubernetes/logs:
+    enabled: true

--- a/tests/llm/fixtures/test_ask_holmes/158_slack_chat_correct_date/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/158_slack_chat_correct_date/test_case.yaml
@@ -8,3 +8,5 @@ user_prompt:
 
 expected_output:
   - This must mention the date 2025-08-23
+tags:
+  - prometheus

--- a/tests/llm/fixtures/test_ask_holmes/159_prometheus_high_cardinality_cpu/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/159_prometheus_high_cardinality_cpu/test_case.yaml
@@ -10,6 +10,7 @@ tags:
   - kubernetes
   - context_window
   - medium
+  - prometheus
 
 # Custom timeout for setup (needs 5 min for metrics + setup time)
 setup_timeout: 420  # 7 minutes total

--- a/tests/llm/fixtures/test_ask_holmes/30_basic_promql_graph_cluster_memory/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/30_basic_promql_graph_cluster_memory/test_case.yaml
@@ -1,5 +1,7 @@
 user_prompt: "Show me a graph (with prometheus) of the memory usage for the kubernetes cluster over the last 30 minutes"
 expected_output:
   - 'The answer should include something similar to << { "type": "promql", "tool_name": "execute_prometheus_range_query", "random_key": "AtEJ" } >>. Both tool_name and random_key MUST absolutely be present and the same as mentioned here.'
+tags:
+  - prometheus
 evaluation:
   correctness: 1

--- a/tests/llm/fixtures/test_ask_holmes/31_basic_promql_graph_pod_memory/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/31_basic_promql_graph_pod_memory/test_case.yaml
@@ -1,5 +1,7 @@
 user_prompt: "Show me a graph of the memory usage for the pod robusta-holmes over the last 30 minutes"
 expected_output:
   - 'The answer should include something similar to << { "type": "promql", "tool_name": "execute_prometheus_range_query", "random_key": "vwJA" } >>. Both tool_name and random_key MUST absolutely be present and the same as mentioned here.'
+tags:
+  - prometheus
 evaluation:
   correctness: 1

--- a/tests/llm/fixtures/test_ask_holmes/32_basic_promql_graph_pod_cpu/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/32_basic_promql_graph_pod_cpu/test_case.yaml
@@ -1,5 +1,7 @@
 user_prompt: "Show me a graph of the CPU usage for the pod robusta-holmes over the last 30 minutes"
 expected_output:
   - 'The answer should include something similar to << { "type": "promql", "tool_name": "execute_prometheus_range_query", "random_key": "HBGf" } >>. Both tool_name and random_key MUST absolutely be present and either the same as mentioned here or Rs0H.'
+tags:
+  - prometheus
 evaluation:
   correctness: 1

--- a/tests/llm/fixtures/test_ask_holmes/33_http_latency_graph/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/33_http_latency_graph/test_case.yaml
@@ -1,6 +1,8 @@
 user_prompt: "Show me the http request latency over time for the service customer-orders-service?"
 expected_output:
   - 'The answer should include something similar to << { "type": "promql", "tool_name": "execute_prometheus_range_query", "random_key": "<alphanumeric code>" } >>.'
+tags:
+  - prometheus
 before_test: kubectl apply -f ./app/manifest.yaml
 after_test: kubectl delete -f ./app/manifest.yaml
 evaluation:

--- a/tests/llm/fixtures/test_ask_holmes/34_memory_graph/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/34_memory_graph/test_case.yaml
@@ -1,5 +1,7 @@
 user_prompt: "Give me a graph of `container_memory_working_set_bytes`"
 expected_output:
   - 'The answer should include something similar to << { "type": "promql", "tool_name": "execute_prometheus_range_query", "random_key": "<alphanumeric_characters>" } >>. Both tool_name and random_key MUST absolutely be present and the same as mentioned here.'
+tags:
+  - prometheus
 evaluation:
   correctness: 1

--- a/tests/llm/fixtures/test_ask_holmes/89_runbook_missing_cloudwatch/test_case.yaml
+++ b/tests/llm/fixtures/test_ask_holmes/89_runbook_missing_cloudwatch/test_case.yaml
@@ -3,6 +3,7 @@ tags:
   - runbooks
   - transparency
   - medium
+  - prometheus
 
 expected_output: |
   - Finds Lambda performance troubleshooting runbook

--- a/tests/llm/utils/property_manager.py
+++ b/tests/llm/utils/property_manager.py
@@ -119,9 +119,34 @@ def update_test_results(
             if isinstance(test_case.evaluation.correctness, Evaluation):
                 evaluation_type = test_case.evaluation.correctness.type
 
+        # Prepare output for evaluation - include tool calls if requested
+        evaluation_output = output
+        if (
+            test_case.include_tool_calls
+            and result
+            and hasattr(result, "tool_calls")
+            and result.tool_calls
+        ):
+            # Format tool calls as a string to include in evaluation
+            tool_calls_text = "\n\n=== Tool Calls ===\n"
+            for i, tc in enumerate(result.tool_calls, 1):
+                tool_calls_text += f"\nTool #{i}: {tc.description}\n"
+                if hasattr(tc, "output") and tc.output:
+                    # Truncate very long outputs
+                    output_text = str(tc.output)
+                    if len(output_text) > 500:
+                        output_text = output_text[:500] + "... [truncated]"
+                    # Indent the output for readability
+                    indented_output = "\n".join(
+                        f"  {line}" for line in output_text.split("\n")
+                    )
+                    tool_calls_text += f"Output:\n{indented_output}\n"
+                tool_calls_text += "---\n"
+            evaluation_output = output + tool_calls_text
+
         # Evaluate correctness
         correctness_eval = evaluate_correctness(
-            output=output,
+            output=evaluation_output,
             expected_elements=expected,
             parent_span=eval_span,
             evaluation_type=evaluation_type,

--- a/tests/llm/utils/test_case_utils.py
+++ b/tests/llm/utils/test_case_utils.py
@@ -74,6 +74,7 @@ class HolmesTestCase(BaseModel):
     skip_reason: Optional[str] = None
     expected_output: Union[str, List[str]]  # Whether an output is expected
     evaluation: LLMEvaluations = LLMEvaluations()
+    include_tool_calls: Optional[bool] = False  # Include tool calls in LLM evaluation
     before_test: Optional[str] = None
     after_test: Optional[str] = None
     setup_timeout: Optional[int] = None  # Override default setup timeout in seconds


### PR DESCRIPTION
Add an eval to test for undesired behaviour reported by a customer: holmes refuses to investigate kafka lag using Prometheus, because it insists on telling the user to enable the Kafka toolset first.

This behaviour will be fixed in a separate PR - this PR only includes the eval.
This PR also improves error handling in the evals framework.