### PR TITLE
add initial feedback command

### DIFF
--- a/holmes/core/feedback.py
+++ b/holmes/core/feedback.py
@@ -1,0 +1,176 @@
+from typing import Callable, Optional
+from .llm import LLM
+
+
+class FeedbackLLM:
+    """Class to represent a LLM in the feedback."""
+
+    def __init__(self, model: str, max_context_size: int):
+        self.model = model
+        self.max_context_size = max_context_size
+
+    def update_from_llm(self, llm: LLM):
+        self.model = llm.model
+        self.max_context_size = llm.get_context_window_size()
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary representation."""
+        return {
+            'model': self.model,
+            'max_context_size': self.max_context_size
+        }
+
+
+# TODO: extend the FeedbackLLMResponse to include each tool call results details used for evaluate the overall response.
+# Currenlty tool call details in plan:
+# - toolcall parameter and success/failure, toolcall truncation size
+# - Holmes plan (todo list)
+# - Holmes intermediate output
+class FeedbackLLMResponse:
+    """Class to represent a LLM response in the feedback"""
+
+    def __init__(self, user_ask: str, response: str):
+        self.user_ask = user_ask
+        self.response = response
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary representation."""
+        return {
+            'user_ask': self.user_ask,
+            'response': self.response
+        }
+
+
+class FeedbackMetadata:
+    """Class to store feedback metadata."""
+
+    def __init__(self, llm_responses: Optional[list[FeedbackLLMResponse]] = None):
+        # In iteration mode, there can be multiple ask and response pairs.
+        self.llm_responses = llm_responses if llm_responses is not None else []
+        self.llm = FeedbackLLM("", 0)
+
+    def add_llm_response(self, user_ask: str, response: str) -> None:
+        """Add a LLM response to the metadata."""
+        llm_response = FeedbackLLMResponse(user_ask, response)
+        self.llm_responses.append(llm_response)
+
+    def update_llm(self, llm: LLM) -> None:
+        """Update the LLM information in the metadata."""
+        self.llm.update_from_llm(llm)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary representation."""
+        return {
+            'llm_responses': [resp.to_dict() for resp in self.llm_responses],
+            'llm': self.llm.to_dict()
+        }
+
+
+class UserFeedback:
+    """Class to store user rate and comment to the AI response."""
+
+    def __init__(self, is_positive: bool, comment: Optional[str]):
+        self.is_positive = is_positive
+        self.comment = comment
+
+    @property
+    def rating_text(self) -> str:
+        """Return human-readable rating text."""
+        return "useful" if self.is_positive else "not useful"
+
+    @property
+    def rating_emoji(self) -> str:
+        """Return emoji representation of the rating."""
+        return "👍" if self.is_positive else "👎"
+
+    def __str__(self) -> str:
+        """Return string representation of the feedback."""
+        if self.comment:
+            return f"Rating: {self.rating_text}. Comment: {self.comment}"
+        else:
+            return f"Rating: {self.rating_text}. No additional comment."
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary representation."""
+        return {
+            'is_positive': self.is_positive,
+            'comment': self.comment,
+        }
+
+
+class Feedback:
+    """Class to store overall feedback data used to evaluate the AI response."""
+
+    def __init__(self):
+        self.metadata = FeedbackMetadata()
+        self.user_feedback: Optional[UserFeedback] = None
+
+    def set_user_feedback(self, user_feedback: UserFeedback) -> None:
+        """Set the user feedback."""
+        self.user_feedback = user_feedback
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary representation."""
+        return {
+            'metadata': self.metadata.to_dict(),
+            'user_feedback': self.user_feedback.to_dict() if self.user_feedback else None
+        }
+
+
+FeedbackCallback = Callable[[Feedback], None]
+
+
+def feedback_callback_example(feedback: Feedback) -> None:
+    """
+    Example implementation of a feedback callback function.
+
+    This function demonstrates how to process feedback data using to_dict() methods
+    and could be used for:
+    - Logging feedback to files or databases
+    - Sending feedback to analytics services
+    - Training data collection
+    - User satisfaction monitoring
+
+    Args:
+        feedback: Feedback object containing user feedback and metadata
+    """
+    print("\n=== Feedback Received ===")
+
+    # Convert entire feedback to dict first - this is the main data structure
+    feedback_dict = feedback.to_dict()
+    print(f"Complete feedback dictionary keys: {list(feedback_dict.keys())}")
+
+    # How to check user feedback using to_dict()
+    print("\n1. Checking User Feedback:")
+    user_feedback_dict = feedback.user_feedback.to_dict()
+    if user_feedback_dict:
+        print(f"   User feedback dict: {user_feedback_dict}")
+        print(f"   Is positive: {user_feedback_dict['is_positive']}")
+        print(f"   Comment: {user_feedback_dict['comment'] or 'None'}")
+        # You can also access properties through the object:
+        print(f"   Rating emoji: {feedback.user_feedback.rating_emoji}")
+        print(f"   Rating text: {feedback.user_feedback.rating_text}")
+    else:
+        print("   No user feedback provided (user_feedback is None)")
+
+    # How to check LLM information using to_dict()
+    print("\n2. Checking LLM Information:")
+    metadata_dict = feedback.metadata.to_dict()
+    llm_dict = metadata_dict['llm']
+    print(f"   LLM dict: {llm_dict}")
+    print(f"   Model: {llm_dict['model']}")
+    print(f"   Max context size: {llm_dict['max_context_size']}")
+
+    # How to check ask and response pairs using to_dict()
+    print("\n3. Checking Ask and Response History:")
+    llm_responses_dict = metadata_dict['llm_responses']
+    print(f"   Number of exchanges: {len(llm_responses_dict)}")
+
+    for i, response_dict in enumerate(llm_responses_dict, 1):
+        print(f"   Exchange {i} dict: {list(response_dict.keys())}")
+        user_ask = response_dict['user_ask']
+        ai_response = response_dict['response']
+        print(f"     User ask: {user_ask}")
+        print(f"     AI response: {ai_response}")
+
+    print("=== End Feedback ===\n")

--- a/holmes/interactive.py
+++ b/holmes/interactive.py
@@ -30,6 +30,7 @@ from rich.markdown import Markdown, Panel
 from holmes.common.env_vars import ENABLE_CLI_TOOL_APPROVAL
 from holmes.core.config import config_path_dir
 from holmes.core.prompt import build_initial_ask_messages
+from holmes.core.feedback import UserFeedback, Feedback, FeedbackCallback
 from holmes.core.tool_calling_llm import ToolCallingLLM, ToolCallResult
 from holmes.core.tools import StructuredToolResult, pretty_print_toolset_status
 from holmes.core.tracing import DummyTracer
@@ -62,19 +63,24 @@ class SlashCommands(Enum):
     )
     CONTEXT = ("/context", "Show conversation context size and token count")
     SHOW = ("/show", "Show specific tool output in scrollable view")
+    FEEDBACK = ("/feedback", "Provide feedback on the agent's response")
 
     def __init__(self, command, description):
         self.command = command
         self.description = description
 
 
-SLASH_COMMANDS_REFERENCE = {cmd.command: cmd.description for cmd in SlashCommands}
-ALL_SLASH_COMMANDS = [cmd.command for cmd in SlashCommands]
-
-
 class SlashCommandCompleter(Completer):
-    def __init__(self):
-        self.commands = SLASH_COMMANDS_REFERENCE
+    def __init__(self, unsupported_commands: Optional[List[str]] = None):
+        # Build commands dictionary, excluding unsupported commands
+        all_commands = {cmd.command: cmd.description for cmd in SlashCommands}
+        if unsupported_commands:
+            self.commands = {
+                cmd: desc for cmd, desc in all_commands.items()
+                if cmd not in unsupported_commands
+            }
+        else:
+            self.commands = all_commands
 
     def get_completions(self, document, complete_event):
         text = document.text_before_cursor
@@ -811,6 +817,62 @@ def handle_last_command(
         )
 
 
+def handle_feedback_command(
+    session: PromptSession,
+    style: Style,
+    console: Console,
+) -> UserFeedback:
+    """Handle the /feedback command to collect user feedback."""
+    # Create a temporary session without history for feedback prompts
+    temp_session = PromptSession(history=InMemoryHistory())  # type: ignore
+
+    # Ask for thumbs up/down rating with validation
+    while True:
+        rating_prompt = temp_session.prompt(
+            [("class:prompt", "Was this response useful to you? 👍(y)/👎(n): ")],
+            style=style,
+        )
+
+        rating_lower = rating_prompt.lower().strip()
+        if rating_lower in ["y", "n"]:
+            break
+        else:
+            console.print(
+                "[bold red]Please enter only 'y' for yes or 'n' for no.[/bold red]"
+            )
+
+    # Determine rating
+    is_positive = rating_lower == "y"
+
+    # Ask for additional comments
+    comment_prompt = temp_session.prompt(
+        [
+            (
+                "class:prompt",
+                "Do you want to provide any additional comments for feedback? (press Enter to skip): ",
+            )
+        ],
+        style=style,
+    )
+
+    comment = comment_prompt.strip() if comment_prompt.strip() else None
+
+    # Create UserFeedback object
+    user_feedback = UserFeedback(is_positive, comment)
+
+    # Display confirmation
+    if comment:
+        console.print(
+            f'[bold green]✓ Feedback recorded (rating={user_feedback.rating_emoji}, "{comment}")[/bold green]'
+        )
+    else:
+        console.print(
+            f"[bold green]✓ Feedback recorded (rating={user_feedback.rating_emoji}, no comment)[/bold green]"
+        )
+
+    return user_feedback
+
+
 def display_recent_tool_outputs(
     tool_calls: List[ToolCallResult],
     console: Console,
@@ -823,7 +885,10 @@ def display_recent_tool_outputs(
     for tool_call in tool_calls:
         tool_index = find_tool_index_in_history(tool_call, all_tool_calls_history)
         preview_output = format_tool_call_output(tool_call, tool_index)
-        title = f"{tool_call.result.status.to_emoji()} {tool_call.description} -> returned {tool_call.result.return_code}"
+        title = (
+            f"{tool_call.result.status.to_emoji()} {tool_call.description} -> "
+            f"returned {tool_call.result.return_code}"
+        )
 
         console.print(
             Panel(
@@ -846,6 +911,7 @@ def run_interactive_loop(
     runbooks=None,
     system_prompt_additions: Optional[str] = None,
     check_version: bool = True,
+    feedback_callback: Optional[FeedbackCallback] = None,
 ) -> None:
     # Initialize tracer - use DummyTracer if no tracer provided
     if tracer is None:
@@ -874,7 +940,11 @@ def run_interactive_loop(
         ai.approval_callback = approval_handler
 
     # Create merged completer with slash commands, conditional executables, show command, and smart paths
-    slash_completer = SlashCommandCompleter()
+    # TODO: remove unsupported_commands support once we implement feedback callback
+    unsupported_commands = []
+    if feedback_callback is None:
+        unsupported_commands.append(SlashCommands.FEEDBACK.command)
+    slash_completer = SlashCommandCompleter(unsupported_commands)
     executable_completer = ConditionalExecutableCompleter()
     show_completer = ShowCommandCompleter()
     path_completer = SmartPathCompleter()
@@ -890,6 +960,9 @@ def run_interactive_loop(
     history = FileHistory(history_file)
     if initial_user_input:
         history.append_string(initial_user_input)
+
+    feedback = Feedback()
+    feedback.metadata.update_llm(ai.llm)
 
     # Create custom key bindings for Ctrl+C behavior
     bindings = KeyBindings()
@@ -985,14 +1058,14 @@ def run_interactive_loop(
             if user_input.startswith("/"):
                 original_input = user_input.strip()
                 command = original_input.lower()
-
                 # Handle prefix matching for slash commands
-                matches = [cmd for cmd in ALL_SLASH_COMMANDS if cmd.startswith(command)]
+                matches = [cmd for cmd in slash_completer.commands.keys() if cmd.startswith(command)]
                 if len(matches) == 1:
                     command = matches[0]
                 elif len(matches) > 1:
                     console.print(
-                        f"[bold {ERROR_COLOR}]Ambiguous command '{command}'. Matches: {', '.join(matches)}[/bold {ERROR_COLOR}]"
+                        f"[bold {ERROR_COLOR}]Ambiguous command '{command}'. "
+                        f"Matches: {', '.join(matches)}[/bold {ERROR_COLOR}]"
                     )
                     continue
 
@@ -1002,13 +1075,20 @@ def run_interactive_loop(
                     console.print(
                         f"[bold {HELP_COLOR}]Available commands:[/bold {HELP_COLOR}]"
                     )
-                    for cmd, description in SLASH_COMMANDS_REFERENCE.items():
+                    for cmd, description in slash_completer.commands.items():
+                        # Only show feedback command if callback is available
+                        if (
+                            cmd == SlashCommands.FEEDBACK.command
+                            and feedback_callback is None
+                        ):
+                            continue
                         console.print(f"  [bold]{cmd}[/bold] - {description}")
                     continue
                 elif command == SlashCommands.CLEAR.command:
                     console.clear()
                     console.print(
-                        f"[bold {STATUS_COLOR}]Screen cleared and context reset. You can now ask a new question.[/bold {STATUS_COLOR}]"
+                        f"[bold {STATUS_COLOR}]Screen cleared and context reset. "
+                        f"You can now ask a new question.[/bold {STATUS_COLOR}]"
                     )
                     messages = None
                     last_response = None
@@ -1034,12 +1114,12 @@ def run_interactive_loop(
                     continue
                 elif command.startswith(SlashCommands.SHOW.command):
                     # Parse the command to extract tool index or name
-                    show_arg = original_input[len(SlashCommands.SHOW.command) :].strip()
+                    show_arg = original_input[len(SlashCommands.SHOW.command):].strip()
                     handle_show_command(show_arg, all_tool_calls_history, console)
                     continue
                 elif command.startswith(SlashCommands.RUN.command):
                     bash_command = original_input[
-                        len(SlashCommands.RUN.command) :
+                        len(SlashCommands.RUN.command):
                     ].strip()
                     shared_input = handle_run_command(
                         bash_command, session, style, console
@@ -1052,6 +1132,14 @@ def run_interactive_loop(
                     if shared_input is None:
                         continue  # User chose not to share or no output, continue to next input
                     user_input = shared_input
+                elif (
+                    command == SlashCommands.FEEDBACK.command
+                    and feedback_callback is not None
+                ):
+                    user_feedback = handle_feedback_command(session, style, console)
+                    feedback.user_feedback = user_feedback
+                    feedback_callback(feedback)
+                    return
                 else:
                     console.print(f"Unknown command: {command}")
                     continue
@@ -1091,6 +1179,7 @@ def run_interactive_loop(
 
             messages = response.messages  # type: ignore
             last_response = response
+            feedback.metadata.add_llm_response(user_input, response.result)
 
             if response.tool_calls:
                 all_tool_calls_history.extend(response.tool_calls)

--- a/holmes/main.py
+++ b/holmes/main.py
@@ -1,4 +1,33 @@
 # ruff: noqa: E402
+from holmes.utils.file_utils import write_json_file
+from holmes.utils.console.result import handle_result
+from holmes.utils.console.logging import init_logging
+from holmes.utils.console.consts import system_prompt_help
+from holmes.plugins.sources.opsgenie import OPSGENIE_TEAM_INTEGRATION_KEY_HELP
+from holmes.plugins.prompts import load_and_render_prompt
+from holmes.plugins.interfaces import Issue
+from holmes.plugins.destinations import DestinationType
+from holmes.interactive import run_interactive_loop
+from holmes.core.tracing import SpanType, TracingFactory
+from holmes.core.tools import pretty_print_toolset_status
+from holmes.core.resource_instruction import ResourceInstructionDocument
+from holmes.core.prompt import build_initial_ask_messages
+from holmes.config import (
+    DEFAULT_CONFIG_LOCATION,
+    Config,
+    SourceFactory,
+    SupportedTicketSources,
+)
+from holmes import get_version  # type: ignore
+from rich.rule import Rule
+from rich.markdown import Markdown
+import typer
+from typing import List, Optional
+from pathlib import Path
+import uuid
+import socket
+import logging
+import json
 import os
 import sys
 
@@ -12,38 +41,6 @@ if add_custom_certificate(ADDITIONAL_CERTIFICATE):
 # DO NOT ADD ANY IMPORTS OR CODE ABOVE THIS LINE
 # IMPORTING ABOVE MIGHT INITIALIZE AN HTTPS CLIENT THAT DOESN'T TRUST THE CUSTOM CERTIFICATE
 
-
-import json
-import logging
-import socket
-import uuid
-from pathlib import Path
-from typing import List, Optional
-
-import typer
-from rich.markdown import Markdown
-from rich.rule import Rule
-
-from holmes import get_version  # type: ignore
-from holmes.config import (
-    DEFAULT_CONFIG_LOCATION,
-    Config,
-    SourceFactory,
-    SupportedTicketSources,
-)
-from holmes.core.prompt import build_initial_ask_messages
-from holmes.core.resource_instruction import ResourceInstructionDocument
-from holmes.core.tools import pretty_print_toolset_status
-from holmes.core.tracing import SpanType, TracingFactory
-from holmes.interactive import run_interactive_loop
-from holmes.plugins.destinations import DestinationType
-from holmes.plugins.interfaces import Issue
-from holmes.plugins.prompts import load_and_render_prompt
-from holmes.plugins.sources.opsgenie import OPSGENIE_TEAM_INTEGRATION_KEY_HELP
-from holmes.utils.console.consts import system_prompt_help
-from holmes.utils.console.logging import init_logging
-from holmes.utils.console.result import handle_result
-from holmes.utils.file_utils import write_json_file
 
 app = typer.Typer(add_completion=False, pretty_exceptions_show_locals=False)
 investigate_app = typer.Typer(

--- a/tests/core/test_feedback.py
+++ b/tests/core/test_feedback.py
@@ -1,0 +1,373 @@
+from unittest.mock import Mock
+
+from holmes.core.feedback import (
+    FeedbackLLM,
+    FeedbackLLMResponse,
+    FeedbackMetadata,
+    UserFeedback,
+    Feedback,
+    FeedbackCallback
+)
+from holmes.core.llm import LLM
+
+
+class MockLLM(LLM):
+    """Mock LLM class for testing."""
+
+    def __init__(self, model: str = "gpt-3.5-turbo", context_size: int = 4096):
+        self.model = model
+        self._context_size = context_size
+
+    def get_context_window_size(self) -> int:
+        return self._context_size
+
+    def get_maximum_output_token(self) -> int:
+        return 1024
+
+    def count_tokens_for_message(self, messages: list[dict]) -> int:
+        return 100
+
+    def completion(self, *args, **kwargs):
+        return Mock()
+
+
+class TestFeedbackLLM:
+    """Test suite for FeedbackLLM class."""
+
+    def test_init(self):
+        """Test FeedbackLLM initialization."""
+        feedback_llm = FeedbackLLM("gpt-4", 8192)
+
+        assert feedback_llm.model == "gpt-4"
+        assert feedback_llm.max_context_size == 8192
+
+    def test_update_from_llm(self):
+        """Test updating FeedbackLLM from LLM instance."""
+        feedback_llm = FeedbackLLM("old-model", 1000)
+        mock_llm = MockLLM("new-model", 4096)
+
+        feedback_llm.update_from_llm(mock_llm)
+
+        assert feedback_llm.model == "new-model"
+        assert feedback_llm.max_context_size == 4096
+
+    def test_to_dict(self):
+        """Test converting FeedbackLLM to dictionary."""
+        feedback_llm = FeedbackLLM("gpt-4", 8192)
+        result = feedback_llm.to_dict()
+
+        expected = {
+            'model': 'gpt-4',
+            'max_context_size': 8192
+        }
+        assert result == expected
+
+
+class TestFeedbackLLMResponse:
+    """Test suite for FeedbackLLMResponse class."""
+
+    def test_init(self):
+        """Test FeedbackLLMResponse initialization."""
+        response = FeedbackLLMResponse("What is the weather?", "The weather is sunny.")
+
+        assert response.user_ask == "What is the weather?"
+        assert response.response == "The weather is sunny."
+
+    def test_to_dict(self):
+        """Test converting FeedbackLLMResponse to dictionary."""
+        response = FeedbackLLMResponse("Hello", "Hi there!")
+        result = response.to_dict()
+
+        expected = {
+            'user_ask': 'Hello',
+            'response': 'Hi there!'
+        }
+        assert result == expected
+
+    def test_empty_strings(self):
+        """Test FeedbackLLMResponse with empty strings."""
+        response = FeedbackLLMResponse("", "")
+
+        assert response.user_ask == ""
+        assert response.response == ""
+        assert response.to_dict() == {'user_ask': '', 'response': ''}
+
+
+class TestFeedbackMetadata:
+    """Test suite for FeedbackMetadata class."""
+
+    def test_init_default(self):
+        """Test FeedbackMetadata initialization with defaults."""
+        metadata = FeedbackMetadata()
+
+        assert metadata.llm_responses == []
+        assert isinstance(metadata.llm, FeedbackLLM)
+        assert metadata.llm.model == ""
+        assert metadata.llm.max_context_size == 0
+
+    def test_init_with_responses(self):
+        """Test FeedbackMetadata initialization with responses."""
+        responses = [
+            FeedbackLLMResponse("question1", "answer1"),
+            FeedbackLLMResponse("question2", "answer2")
+        ]
+        metadata = FeedbackMetadata(llm_responses=responses)
+
+        assert len(metadata.llm_responses) == 2
+        assert metadata.llm_responses[0].user_ask == "question1"
+        assert metadata.llm_responses[1].user_ask == "question2"
+
+    def test_add_llm_response(self):
+        """Test adding LLM response to metadata."""
+        metadata = FeedbackMetadata()
+
+        metadata.add_llm_response("How are you?", "I'm doing well!")
+
+        assert len(metadata.llm_responses) == 1
+        assert metadata.llm_responses[0].user_ask == "How are you?"
+        assert metadata.llm_responses[0].response == "I'm doing well!"
+
+    def test_add_multiple_llm_responses(self):
+        """Test adding multiple LLM responses."""
+        metadata = FeedbackMetadata()
+
+        metadata.add_llm_response("First question", "First answer")
+        metadata.add_llm_response("Second question", "Second answer")
+
+        assert len(metadata.llm_responses) == 2
+        assert metadata.llm_responses[0].user_ask == "First question"
+        assert metadata.llm_responses[1].user_ask == "Second question"
+
+    def test_update_llm(self):
+        """Test updating LLM information in metadata."""
+        metadata = FeedbackMetadata()
+        mock_llm = MockLLM("claude-3", 12000)
+
+        metadata.update_llm(mock_llm)
+
+        assert metadata.llm.model == "claude-3"
+        assert metadata.llm.max_context_size == 12000
+
+    def test_to_dict_empty(self):
+        """Test converting empty FeedbackMetadata to dictionary."""
+        metadata = FeedbackMetadata()
+        result = metadata.to_dict()
+
+        expected = {
+            'llm_responses': [],
+            'llm': {'model': '', 'max_context_size': 0}
+        }
+        assert result == expected
+
+    def test_to_dict_with_data(self):
+        """Test converting FeedbackMetadata with data to dictionary."""
+        metadata = FeedbackMetadata()
+        metadata.add_llm_response("Question", "Answer")
+        mock_llm = MockLLM("gpt-4", 8192)
+        metadata.update_llm(mock_llm)
+
+        result = metadata.to_dict()
+
+        expected = {
+            'llm_responses': [
+                {'user_ask': 'Question', 'response': 'Answer'}
+            ],
+            'llm': {'model': 'gpt-4', 'max_context_size': 8192}
+        }
+        assert result == expected
+
+
+class TestUserFeedback:
+    """Test suite for UserFeedback class."""
+
+    def test_init_positive(self):
+        """Test UserFeedback initialization with positive feedback."""
+        feedback = UserFeedback(True, "Great response!")
+
+        assert feedback.is_positive is True
+        assert feedback.comment == "Great response!"
+
+    def test_init_negative(self):
+        """Test UserFeedback initialization with negative feedback."""
+        feedback = UserFeedback(False, "Could be better")
+
+        assert feedback.is_positive is False
+        assert feedback.comment == "Could be better"
+
+    def test_init_no_comment(self):
+        """Test UserFeedback initialization without comment."""
+        feedback = UserFeedback(True, None)
+
+        assert feedback.is_positive is True
+        assert feedback.comment is None
+
+    def test_rating_text_positive(self):
+        """Test rating_text property for positive feedback."""
+        feedback = UserFeedback(True, "Good")
+        assert feedback.rating_text == "useful"
+
+    def test_rating_text_negative(self):
+        """Test rating_text property for negative feedback."""
+        feedback = UserFeedback(False, "Bad")
+        assert feedback.rating_text == "not useful"
+
+    def test_rating_emoji_positive(self):
+        """Test rating_emoji property for positive feedback."""
+        feedback = UserFeedback(True, "Good")
+        assert feedback.rating_emoji == "👍"
+
+    def test_rating_emoji_negative(self):
+        """Test rating_emoji property for negative feedback."""
+        feedback = UserFeedback(False, "Bad")
+        assert feedback.rating_emoji == "👎"
+
+    def test_str_with_comment(self):
+        """Test string representation with comment."""
+        feedback = UserFeedback(True, "Very helpful!")
+        expected = "Rating: useful. Comment: Very helpful!"
+        assert str(feedback) == expected
+
+    def test_str_without_comment(self):
+        """Test string representation without comment."""
+        feedback = UserFeedback(False, None)
+        expected = "Rating: not useful. No additional comment."
+        assert str(feedback) == expected
+
+    def test_to_dict_positive_with_comment(self):
+        """Test converting positive feedback with comment to dictionary."""
+        feedback = UserFeedback(True, "Excellent work!")
+        result = feedback.to_dict()
+
+        expected = {
+            'is_positive': True,
+            'comment': 'Excellent work!',
+        }
+        assert result == expected
+
+    def test_to_dict_negative_without_comment(self):
+        """Test converting negative feedback without comment to dictionary."""
+        feedback = UserFeedback(False, None)
+        result = feedback.to_dict()
+
+        expected = {
+            'is_positive': False,
+            'comment': None,
+        }
+        assert result == expected
+
+
+class TestFeedback:
+    """Test suite for Feedback class."""
+
+    def test_init(self):
+        """Test Feedback initialization."""
+        feedback = Feedback()
+
+        assert isinstance(feedback.metadata, FeedbackMetadata)
+        assert feedback.user_feedback is None
+
+    def test_set_user_feedback(self):
+        """Test setting user feedback."""
+        feedback = Feedback()
+        user_feedback = UserFeedback(True, "Great!")
+
+        feedback.set_user_feedback(user_feedback)
+
+        assert feedback.user_feedback == user_feedback
+        assert feedback.user_feedback.is_positive is True
+        assert feedback.user_feedback.comment == "Great!"
+
+    def test_to_dict_without_user_feedback(self):
+        """Test converting Feedback without user feedback to dictionary."""
+        feedback = Feedback()
+        result = feedback.to_dict()
+
+        expected = {
+            'metadata': {
+                'llm_responses': [],
+                'llm': {'model': '', 'max_context_size': 0}
+            },
+            'user_feedback': None
+        }
+        assert result == expected
+
+    def test_to_dict_with_user_feedback(self):
+        """Test converting Feedback with user feedback to dictionary."""
+        feedback = Feedback()
+        user_feedback = UserFeedback(True, "Helpful response")
+        feedback.set_user_feedback(user_feedback)
+
+        # Add some metadata
+        feedback.metadata.add_llm_response("Question", "Answer")
+        mock_llm = MockLLM("gpt-3.5-turbo", 4096)
+        feedback.metadata.update_llm(mock_llm)
+
+        result = feedback.to_dict()
+
+        expected = {
+            'metadata': {
+                'llm_responses': [
+                    {'user_ask': 'Question', 'response': 'Answer'}
+                ],
+                'llm': {'model': 'gpt-3.5-turbo', 'max_context_size': 4096}
+            },
+            'user_feedback': {
+                'is_positive': True,
+                'comment': 'Helpful response',
+            }
+        }
+        assert result == expected
+
+    def test_complete_workflow(self):
+        """Test complete feedback workflow."""
+        feedback = Feedback()
+
+        # Update LLM information
+        mock_llm = MockLLM("claude-3.5-sonnet", 16000)
+        feedback.metadata.update_llm(mock_llm)
+
+        # Add conversation history
+        feedback.metadata.add_llm_response("What is Python?", "Python is a programming language.")
+        feedback.metadata.add_llm_response("How do I install it?", "You can install Python from python.org")
+
+        # Set user feedback
+        user_feedback = UserFeedback(True, "Very informative answers!")
+        feedback.set_user_feedback(user_feedback)
+
+        # Verify complete structure
+        result = feedback.to_dict()
+        assert len(result['metadata']['llm_responses']) == 2
+        assert result['metadata']['llm']['model'] == "claude-3.5-sonnet"
+        assert result['user_feedback']['is_positive'] is True
+        assert result['user_feedback']['comment'] == "Very informative answers!"
+
+
+class TestFeedbackCallback:
+    """Test suite for FeedbackCallback type."""
+
+    def test_callback_signature(self):
+        """Test that FeedbackCallback can be used as a type hint."""
+        def sample_callback(feedback: Feedback) -> None:
+            """Sample callback function."""
+            pass
+
+        # This should type check correctly
+        callback: FeedbackCallback = sample_callback
+
+        # Test that it can be called with a Feedback object
+        feedback = Feedback()
+        callback(feedback)
+
+    def test_callback_with_mock(self):
+        """Test callback functionality with mock."""
+        mock_callback = Mock()
+
+        feedback = Feedback()
+        user_feedback = UserFeedback(True, "Test feedback")
+        feedback.set_user_feedback(user_feedback)
+
+        # Call the mock callback
+        mock_callback(feedback)
+
+        # Verify it was called with the feedback
+        mock_callback.assert_called_once_with(feedback)

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1,0 +1,578 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from rich.console import Console
+from prompt_toolkit.completion import Completion
+
+from holmes.interactive import (
+    run_interactive_loop,
+    SlashCommandCompleter,
+    SlashCommands,
+    SmartPathCompleter,
+    ConditionalExecutableCompleter,
+    ShowCommandCompleter,
+    handle_feedback_command,
+    Feedback,
+    UserFeedback,
+)
+from holmes.core.feedback import FeedbackMetadata
+from holmes.core.tool_calling_llm import ToolCallingLLM
+from tests.mocks.toolset_mocks import SampleToolset
+
+
+class TestSlashCommandCompleter(unittest.TestCase):
+    def test_init_without_unsupported_commands(self):
+        """Test SlashCommandCompleter initialization without unsupported commands."""
+        completer = SlashCommandCompleter()
+        expected_commands = {cmd.command: cmd.description for cmd in SlashCommands}
+        self.assertEqual(completer.commands, expected_commands)
+
+    def test_init_with_unsupported_commands(self):
+        """Test SlashCommandCompleter initialization with unsupported commands."""
+        unsupported = [SlashCommands.FEEDBACK.command]
+        completer = SlashCommandCompleter(unsupported)
+
+        expected_commands = {cmd.command: cmd.description for cmd in SlashCommands}
+        expected_commands.pop(SlashCommands.FEEDBACK.command)
+
+        self.assertEqual(completer.commands, expected_commands)
+
+    def test_get_completions_with_slash_prefix(self):
+        """Test completion suggestions for slash commands."""
+        completer = SlashCommandCompleter()
+        document = Mock()
+        document.text_before_cursor = "/ex"
+
+        completions = list(completer.get_completions(document, None))
+
+        self.assertEqual(len(completions), 1)
+        self.assertEqual(completions[0].text, SlashCommands.EXIT.command)
+
+    def test_get_completions_without_slash_prefix(self):
+        """Test no completions for non-slash input."""
+        completer = SlashCommandCompleter()
+        document = Mock()
+        document.text_before_cursor = "regular input"
+
+        completions = list(completer.get_completions(document, None))
+
+        self.assertEqual(len(completions), 0)
+
+    def test_get_completions_filters_unsupported_commands(self):
+        """Test that unsupported commands are filtered out of completions."""
+        unsupported = [SlashCommands.FEEDBACK.command]
+        completer = SlashCommandCompleter(unsupported)
+        document = Mock()
+        document.text_before_cursor = "/feed"
+
+        completions = list(completer.get_completions(document, None))
+
+        self.assertEqual(len(completions), 0)
+
+
+class TestHandleFeedbackCommand(unittest.TestCase):
+    @patch('holmes.interactive.PromptSession')
+    def test_handle_feedback_command_positive(self, mock_prompt_session_class):
+        """Test feedback command with positive rating."""
+        mock_session = Mock()
+        mock_prompt_session_class.return_value = mock_session
+        mock_session.prompt.side_effect = ["y", "Great response!"]
+
+        console = Mock()
+        style = Mock()
+
+        result = handle_feedback_command(mock_session, style, console)
+
+        self.assertIsInstance(result, UserFeedback)
+        self.assertTrue(result.is_positive)
+        self.assertEqual(result.comment, "Great response!")
+
+    @patch('holmes.interactive.PromptSession')
+    def test_handle_feedback_command_negative(self, mock_prompt_session_class):
+        """Test feedback command with negative rating."""
+        mock_session = Mock()
+        mock_prompt_session_class.return_value = mock_session
+        mock_session.prompt.side_effect = ["n", "Could be better"]
+
+        console = Mock()
+        style = Mock()
+
+        result = handle_feedback_command(mock_session, style, console)
+
+        self.assertIsInstance(result, UserFeedback)
+        self.assertFalse(result.is_positive)
+        self.assertEqual(result.comment, "Could be better")
+
+    @patch('holmes.interactive.PromptSession')
+    def test_handle_feedback_command_no_comment(self, mock_prompt_session_class):
+        """Test feedback command without comment."""
+        mock_session = Mock()
+        mock_prompt_session_class.return_value = mock_session
+        mock_session.prompt.side_effect = ["y", ""]
+
+        console = Mock()
+        style = Mock()
+
+        result = handle_feedback_command(mock_session, style, console)
+
+        self.assertIsInstance(result, UserFeedback)
+        self.assertTrue(result.is_positive)
+        self.assertIsNone(result.comment)
+
+
+class TestRunInteractiveLoop(unittest.TestCase):
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_ai = Mock(spec=ToolCallingLLM)
+        self.mock_ai.llm = Mock()
+        self.mock_ai.llm.model = "test-model"
+        self.mock_ai.llm.get_context_window_size.return_value = 4096
+        self.mock_ai.tool_executor = Mock()
+        self.mock_ai.tool_executor.toolsets = [SampleToolset()]
+
+        # Mock AI response
+        self.mock_response = Mock()
+        self.mock_response.result = "Test response"
+        self.mock_response.messages = []
+        self.mock_response.tool_calls = []
+        self.mock_ai.call.return_value = self.mock_response
+
+        self.mock_console = Mock(spec=Console)
+
+        # Create a temporary directory for history file
+        self.temp_dir = tempfile.mkdtemp()
+        self.history_file = os.path.join(self.temp_dir, "history")
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    @patch('holmes.interactive.check_version_async')
+    @patch('holmes.interactive.PromptSession')
+    @patch('holmes.interactive.build_initial_ask_messages')
+    @patch('holmes.interactive.config_path_dir', new_callable=lambda: tempfile.gettempdir())
+    @patch('holmes.interactive.handle_feedback_command')
+    def test_run_interactive_loop_feedback_command_positive_with_callback(self, mock_handle_feedback,
+                                                                          mock_config_dir,
+                                                                          mock_build_messages,
+                                                                          mock_prompt_session_class,
+                                                                          mock_check_version):
+        """Test interactive loop with /feedback command - positive feedback."""
+        mock_session = Mock()
+        mock_prompt_session_class.return_value = mock_session
+        mock_session.prompt.side_effect = ["/feedback", "/exit"]
+
+        mock_build_messages.return_value = []
+        mock_callback = Mock()
+
+        # Mock the feedback handler to return positive feedback
+        mock_user_feedback = UserFeedback(is_positive=True, comment="Great response!")
+        mock_handle_feedback.return_value = mock_user_feedback
+
+        # Run the interactive loop
+        run_interactive_loop(
+            ai=self.mock_ai,
+            console=self.mock_console,
+            initial_user_input=None,
+            include_files=None,
+            post_processing_prompt=None,
+            show_tool_output=False,
+            check_version=False,
+            feedback_callback=mock_callback,
+        )
+
+        # Verify feedback handler was called
+        mock_handle_feedback.assert_called_once()
+
+        # Verify callback was called with complete Feedback object
+        mock_callback.assert_called_once()
+        call_args = mock_callback.call_args[0][0]
+        
+        # Test complete Feedback structure
+        self.assertIsInstance(call_args, Feedback)
+        
+        # Test UserFeedback component
+        self.assertIsNotNone(call_args.user_feedback)
+        self.assertIsInstance(call_args.user_feedback, UserFeedback)
+        self.assertEqual(call_args.user_feedback.is_positive, True)
+        self.assertEqual(call_args.user_feedback.comment, "Great response!")
+        
+        # Test FeedbackMetadata component
+        self.assertIsNotNone(call_args.metadata)
+        self.assertIsInstance(call_args.metadata, FeedbackMetadata)
+        
+        # Test LLM information in metadata
+        self.assertIsNotNone(call_args.metadata.llm)
+        self.assertEqual(call_args.metadata.llm.model, "test-model")
+        self.assertEqual(call_args.metadata.llm.max_context_size, 4096)
+        
+        # Test LLM responses list (should be empty initially but list should exist)
+        self.assertIsInstance(call_args.metadata.llm_responses, list)
+        
+        # Test to_dict() functionality
+        feedback_dict = call_args.to_dict()
+        self.assertIn('user_feedback', feedback_dict)
+        self.assertIn('metadata', feedback_dict)
+        self.assertEqual(feedback_dict['user_feedback']['is_positive'], True)
+        self.assertEqual(feedback_dict['user_feedback']['comment'], "Great response!")
+        self.assertEqual(feedback_dict['metadata']['llm']['model'], "test-model")
+        self.assertEqual(feedback_dict['metadata']['llm']['max_context_size'], 4096)
+
+    @patch('holmes.interactive.check_version_async')
+    @patch('holmes.interactive.PromptSession')
+    @patch('holmes.interactive.build_initial_ask_messages')
+    @patch('holmes.interactive.config_path_dir', new_callable=lambda: tempfile.gettempdir())
+    @patch('holmes.interactive.handle_feedback_command')
+    def test_run_interactive_loop_feedback_command_negative_with_callback(self, mock_handle_feedback,
+                                                                          mock_config_dir,
+                                                                          mock_build_messages,
+                                                                          mock_prompt_session_class,
+                                                                          mock_check_version):
+        """Test interactive loop with /feedback command - negative feedback."""
+        mock_session = Mock()
+        mock_prompt_session_class.return_value = mock_session
+        mock_session.prompt.side_effect = ["/feedback", "/exit"]
+
+        mock_build_messages.return_value = []
+        mock_callback = Mock()
+
+        # Mock the feedback handler to return negative feedback
+        mock_user_feedback = UserFeedback(is_positive=False, comment="Could be better")
+        mock_handle_feedback.return_value = mock_user_feedback
+
+        # Run the interactive loop
+        run_interactive_loop(
+            ai=self.mock_ai,
+            console=self.mock_console,
+            initial_user_input=None,
+            include_files=None,
+            post_processing_prompt=None,
+            show_tool_output=False,
+            check_version=False,
+            feedback_callback=mock_callback,
+        )
+
+        # Verify callback was called with complete Feedback object containing negative feedback
+        mock_callback.assert_called_once()
+        call_args = mock_callback.call_args[0][0]
+        
+        # Test complete Feedback structure
+        self.assertIsInstance(call_args, Feedback)
+        
+        # Test UserFeedback component
+        self.assertIsNotNone(call_args.user_feedback)
+        self.assertIsInstance(call_args.user_feedback, UserFeedback)
+        self.assertEqual(call_args.user_feedback.is_positive, False)
+        self.assertEqual(call_args.user_feedback.comment, "Could be better")
+        
+        # Test FeedbackMetadata component
+        self.assertIsNotNone(call_args.metadata)
+        self.assertIsInstance(call_args.metadata, FeedbackMetadata)
+        
+        # Test LLM information in metadata
+        self.assertIsNotNone(call_args.metadata.llm)
+        self.assertEqual(call_args.metadata.llm.model, "test-model")
+        self.assertEqual(call_args.metadata.llm.max_context_size, 4096)
+        
+        # Test LLM responses list
+        self.assertIsInstance(call_args.metadata.llm_responses, list)
+        
+        # Test to_dict() functionality for negative feedback
+        feedback_dict = call_args.to_dict()
+        self.assertIn('user_feedback', feedback_dict)
+        self.assertIn('metadata', feedback_dict)
+        self.assertEqual(feedback_dict['user_feedback']['is_positive'], False)
+        self.assertEqual(feedback_dict['user_feedback']['comment'], "Could be better")
+        self.assertEqual(feedback_dict['metadata']['llm']['model'], "test-model")
+        self.assertEqual(feedback_dict['metadata']['llm']['max_context_size'], 4096)
+        self.assertIsInstance(feedback_dict['metadata']['llm_responses'], list)
+
+    @patch('holmes.interactive.check_version_async')
+    @patch('holmes.interactive.PromptSession')
+    @patch('holmes.interactive.build_initial_ask_messages')
+    @patch('holmes.interactive.config_path_dir', new_callable=lambda: tempfile.gettempdir())
+    @patch('holmes.interactive.handle_feedback_command')
+    def test_run_interactive_loop_feedback_with_conversation_history(self, mock_handle_feedback,
+                                                                     mock_config_dir,
+                                                                     mock_build_messages,
+                                                                     mock_prompt_session_class,
+                                                                     mock_check_version):
+        """Test feedback system with conversation history (LLM responses)."""
+        mock_session = Mock()
+        mock_prompt_session_class.return_value = mock_session
+        mock_session.prompt.side_effect = ["What is Kubernetes?", "/feedback", "/exit"]
+
+        mock_build_messages.return_value = [{"role": "user", "content": "What is Kubernetes?"}]
+        mock_callback = Mock()
+
+        # Mock the feedback handler to return feedback
+        mock_user_feedback = UserFeedback(is_positive=True, comment="Very helpful!")
+        mock_handle_feedback.return_value = mock_user_feedback
+
+        # Mock tracer for the normal query
+        mock_tracer = Mock()
+        mock_trace_span = Mock()
+        mock_tracer.start_trace.return_value.__enter__ = Mock(return_value=mock_trace_span)
+        mock_tracer.start_trace.return_value.__exit__ = Mock(return_value=None)
+        mock_tracer.get_trace_url.return_value = None
+
+        # Run the interactive loop with a conversation
+        run_interactive_loop(
+            ai=self.mock_ai,
+            console=self.mock_console,
+            initial_user_input=None,
+            include_files=None,
+            post_processing_prompt=None,
+            show_tool_output=False,
+            check_version=False,
+            feedback_callback=mock_callback,
+            tracer=mock_tracer,
+        )
+
+        # Verify callback was called with Feedback containing conversation history
+        mock_callback.assert_called_once()
+        call_args = mock_callback.call_args[0][0]
+        
+        # Test complete Feedback structure with conversation history
+        self.assertIsInstance(call_args, Feedback)
+        
+        # Test UserFeedback component
+        self.assertIsNotNone(call_args.user_feedback)
+        self.assertEqual(call_args.user_feedback.is_positive, True)
+        self.assertEqual(call_args.user_feedback.comment, "Very helpful!")
+        
+        # Test FeedbackMetadata with LLM responses
+        self.assertIsNotNone(call_args.metadata)
+        self.assertIsInstance(call_args.metadata, FeedbackMetadata)
+        
+        # Test LLM information
+        self.assertEqual(call_args.metadata.llm.model, "test-model")
+        self.assertEqual(call_args.metadata.llm.max_context_size, 4096)
+        
+        # Test LLM responses list contains the conversation
+        self.assertIsInstance(call_args.metadata.llm_responses, list)
+        self.assertGreaterEqual(len(call_args.metadata.llm_responses), 1)  # Should have at least one exchange
+        
+        # Test to_dict() functionality with conversation history
+        feedback_dict = call_args.to_dict()
+        self.assertIn('metadata', feedback_dict)
+        self.assertIn('llm_responses', feedback_dict['metadata'])
+        self.assertIsInstance(feedback_dict['metadata']['llm_responses'], list)
+        
+        # If there are responses, verify their structure
+        if feedback_dict['metadata']['llm_responses']:
+            first_response = feedback_dict['metadata']['llm_responses'][0]
+            self.assertIn('user_ask', first_response)
+            self.assertIn('response', first_response)
+            self.assertIsInstance(first_response['user_ask'], str)
+            self.assertIsInstance(first_response['response'], str)
+
+    @patch('holmes.interactive.check_version_async')
+    @patch('holmes.interactive.PromptSession')
+    @patch('holmes.interactive.build_initial_ask_messages')
+    @patch('holmes.interactive.config_path_dir', new_callable=lambda: tempfile.gettempdir())
+    def test_run_interactive_loop_feedback_command_without_callback(self, mock_config_dir,
+                                                                    mock_build_messages,
+                                                                    mock_prompt_session_class,
+                                                                    mock_check_version):
+        """Test interactive loop with /feedback command when no callback is provided."""
+        mock_session = Mock()
+        mock_prompt_session_class.return_value = mock_session
+        mock_session.prompt.side_effect = ["/feedback", "/exit"]
+
+        mock_build_messages.return_value = []
+
+        # Run the interactive loop without feedback callback
+        run_interactive_loop(
+            ai=self.mock_ai,
+            console=self.mock_console,
+            initial_user_input=None,
+            include_files=None,
+            post_processing_prompt=None,
+            show_tool_output=False,
+            check_version=False,
+            feedback_callback=None,  # No callback
+        )
+
+        # Verify "Unknown command" message was displayed
+        unknown_calls = [call_args for call_args in self.mock_console.print.call_args_list
+                         if "Unknown command" in str(call_args)]
+        self.assertTrue(len(unknown_calls) > 0)
+
+    @patch('holmes.interactive.check_version_async')
+    @patch('holmes.interactive.PromptSession')
+    @patch('holmes.interactive.build_initial_ask_messages')
+    @patch('holmes.interactive.config_path_dir', new_callable=lambda: tempfile.gettempdir())
+    def test_run_interactive_loop_feedback_help_filtering(self, mock_config_dir,
+                                                          mock_build_messages,
+                                                          mock_prompt_session_class,
+                                                          mock_check_version):
+        """Test that help command filters out feedback when callback is None."""
+        mock_session = Mock()
+        mock_prompt_session_class.return_value = mock_session
+        mock_session.prompt.side_effect = ["/help", "/exit"]
+
+        mock_build_messages.return_value = []
+
+        # Run without feedback callback
+        run_interactive_loop(
+            ai=self.mock_ai,
+            console=self.mock_console,
+            initial_user_input=None,
+            include_files=None,
+            post_processing_prompt=None,
+            show_tool_output=False,
+            check_version=False,
+            feedback_callback=None,
+        )
+
+        # Check all printed messages
+        all_prints = [str(call_args) for call_args in self.mock_console.print.call_args_list]
+
+        # Should contain help for other commands but not feedback
+        has_help_command = any("/help" in print_msg for print_msg in all_prints)
+        has_exit_command = any("/exit" in print_msg for print_msg in all_prints)
+        has_feedback_command = any("/feedback" in print_msg for print_msg in all_prints)
+
+        self.assertTrue(has_help_command)
+        self.assertTrue(has_exit_command)
+        self.assertFalse(has_feedback_command)  # Should be filtered out
+
+    @patch('holmes.interactive.check_version_async')
+    @patch('holmes.interactive.PromptSession')
+    @patch('holmes.interactive.build_initial_ask_messages')
+    @patch('holmes.interactive.config_path_dir', new_callable=lambda: tempfile.gettempdir())
+    def test_run_interactive_loop_feedback_help_not_filtering_with_callback(self, mock_config_dir,
+                                                                            mock_build_messages,
+                                                                            mock_prompt_session_class,
+                                                                            mock_check_version):
+        """Test that help command shows feedback when callback is provided."""
+        mock_session = Mock()
+        mock_prompt_session_class.return_value = mock_session
+        mock_session.prompt.side_effect = ["/help", "/exit"]
+
+        mock_build_messages.return_value = []
+        mock_callback = Mock()
+
+        # Run with feedback callback
+        run_interactive_loop(
+            ai=self.mock_ai,
+            console=self.mock_console,
+            initial_user_input=None,
+            include_files=None,
+            post_processing_prompt=None,
+            show_tool_output=False,
+            check_version=False,
+            feedback_callback=mock_callback,
+        )
+
+        # Check all printed messages
+        all_prints = [str(call_args) for call_args in self.mock_console.print.call_args_list]
+
+        # Should contain help for feedback command
+        has_feedback_command = any("/feedback" in print_msg for print_msg in all_prints)
+        self.assertTrue(has_feedback_command)  # Should be shown
+
+    @patch('holmes.interactive.check_version_async')
+    @patch('holmes.interactive.PromptSession')
+    @patch('holmes.interactive.build_initial_ask_messages')
+    @patch('holmes.interactive.config_path_dir', new_callable=lambda: tempfile.gettempdir())
+    def test_run_interactive_loop_with_initial_input(self, mock_config_dir, mock_build_messages,
+                                                     mock_prompt_session_class, mock_check_version):
+        """Test interactive loop with initial user input."""
+        mock_session = Mock()
+        mock_prompt_session_class.return_value = mock_session
+        mock_session.prompt.side_effect = ["/exit"]  # Only need exit after initial input
+
+        initial_input = "What is kubernetes?"
+        mock_build_messages.return_value = [{"role": "user", "content": initial_input}]
+
+        # Mock tracer
+        mock_tracer = Mock()
+        mock_trace_span = Mock()
+        mock_tracer.start_trace.return_value.__enter__ = Mock(return_value=mock_trace_span)
+        mock_tracer.start_trace.return_value.__exit__ = Mock(return_value=None)
+        mock_tracer.get_trace_url.return_value = None
+
+        # Run the interactive loop
+        run_interactive_loop(
+            ai=self.mock_ai,
+            console=self.mock_console,
+            initial_user_input=initial_input,
+            include_files=None,
+            post_processing_prompt=None,
+            show_tool_output=False,
+            check_version=False,
+            tracer=mock_tracer,
+        )
+
+        # Verify initial input was displayed
+        initial_calls = [call_args for call_args in self.mock_console.print.call_args_list
+                         if initial_input in str(call_args)]
+        self.assertTrue(len(initial_calls) > 0)
+
+        # Verify AI was called with initial input
+        self.mock_ai.call.assert_called_once()
+
+    @patch('holmes.interactive.check_version_async')
+    @patch('holmes.interactive.PromptSession')
+    @patch('holmes.interactive.build_initial_ask_messages')
+    @patch('holmes.interactive.config_path_dir', new_callable=lambda: tempfile.gettempdir())
+    def test_run_interactive_loop_exception_handling(self, mock_config_dir, mock_build_messages,
+                                                     mock_prompt_session_class, mock_check_version):
+        """Test interactive loop exception handling."""
+        mock_session = Mock()
+        mock_prompt_session_class.return_value = mock_session
+        # First call raises exception, second call exits
+        mock_session.prompt.side_effect = [Exception("Test error"), "/exit"]
+
+        mock_build_messages.return_value = []
+
+        # Run the interactive loop
+        run_interactive_loop(
+            ai=self.mock_ai,
+            console=self.mock_console,
+            initial_user_input=None,
+            include_files=None,
+            post_processing_prompt=None,
+            show_tool_output=False,
+            check_version=False,
+        )
+
+        # Verify error was displayed
+        error_calls = [call_args for call_args in self.mock_console.print.call_args_list
+                       if "Error:" in str(call_args)]
+        self.assertTrue(len(error_calls) > 0)
+
+    def test_run_interactive_loop_unsupported_commands_without_callback(self):
+        """Test that feedback command is not available when callback is None."""
+        with patch('holmes.interactive.check_version_async'), \
+                patch('holmes.interactive.PromptSession') as mock_prompt_session_class, \
+                patch('holmes.interactive.build_initial_ask_messages'), \
+                patch('holmes.interactive.config_path_dir', return_value=tempfile.gettempdir()):
+
+            mock_session = Mock()
+            mock_prompt_session_class.return_value = mock_session
+            mock_session.prompt.side_effect = ["/help", "/exit"]
+
+            # Run the interactive loop without feedback callback
+            run_interactive_loop(
+                ai=self.mock_ai,
+                console=self.mock_console,
+                initial_user_input=None,
+                include_files=None,
+                post_processing_prompt=None,
+                show_tool_output=False,
+                check_version=False,
+                feedback_callback=None,  # No callback
+            )
+
+            # Verify feedback command is not shown in help
+            help_calls = [str(call_args) for call_args in self.mock_console.print.call_args_list]
+
+            # The feedback command should not be shown since callback is None
+            has_feedback_in_help = any("/feedback" in call_str for call_str in help_calls)
+            self.assertFalse(has_feedback_in_help)


### PR DESCRIPTION
When feedback callback is not None, we'll show the /feedback command though completer and /help command.
The feedback includes both the user feedback and metadata. metadata contains a shortcut of llm and list of ask/response until now, and more metadata is going to be added.

```
User: /feedback
Was this response useful to you? 👍(y)/👎(n): y
Do you want to provide any additional comments for feedback? (press Enter to skip): not bad
✓ Feedback recorded (rating=👍, "not bad")
```