### PR TITLE
mute unncessary info log for console

### DIFF
--- a/holmes/config.py
+++ b/holmes/config.py
@@ -9,11 +9,8 @@ import sentry_sdk
 import yaml  # type: ignore
 from pydantic import BaseModel, ConfigDict, FilePath, PrivateAttr, SecretStr
 
-
+from holmes.common.env_vars import ROBUSTA_CONFIG_PATH
 from holmes.core.llm import DefaultLLM, LLMModelRegistry
-from holmes.common.env_vars import (
-    ROBUSTA_CONFIG_PATH,
-)
 from holmes.core.tools_utils.tool_executor import ToolExecutor
 from holmes.core.toolset_manager import ToolsetManager
 from holmes.plugins.runbooks import (
@@ -33,8 +30,8 @@ if TYPE_CHECKING:
     from holmes.plugins.sources.pagerduty import PagerDutySource
     from holmes.plugins.sources.prometheus.plugin import AlertManagerSource
 
-from holmes.core.supabase_dal import SupabaseDal
 from holmes.core.config import config_path_dir
+from holmes.core.supabase_dal import SupabaseDal
 from holmes.utils.definitions import RobustaConfig
 from holmes.utils.pydantic_utils import RobustaBaseConfig, load_model_from_file
 
@@ -129,10 +126,12 @@ class Config(RobustaBaseConfig):
         return self._llm_model_registry
 
     def log_useful_info(self):
-        if self.llm_model_registry and self.llm_model_registry.models:
-            logging.info(
-                f"Loaded models: {list(self.llm_model_registry.models.keys())}"
-            )
+        # log the model list when we have more than configured model.
+        if self.llm_model_registry.models:
+            if len(self.llm_model_registry.models) > 1:
+                logging.info(
+                    f"Loaded models: {list(self.llm_model_registry.models.keys())}"
+                )
         else:
             logging.warning("No llm models were loaded")
 

--- a/holmes/core/supabase_dal.py
+++ b/holmes/core/supabase_dal.py
@@ -1,5 +1,6 @@
 import base64
 import binascii
+import gzip
 import json
 import logging
 import os
@@ -7,7 +8,6 @@ import threading
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
 from uuid import uuid4
-import gzip
 
 import yaml  # type: ignore
 from cachetools import TTLCache  # type: ignore
@@ -66,7 +66,7 @@ class SupabaseDal:
         self.enabled = self.__init_config()
         self.cluster = cluster
         if not self.enabled:
-            logging.info(
+            logging.debug(
                 "Not connecting to Robusta platform - robusta token not provided - using ROBUSTA_AI will not be possible"
             )
             return
@@ -124,7 +124,7 @@ class SupabaseDal:
                 )
 
         if not os.path.exists(config_file_path):
-            logging.info(f"No robusta config in {config_file_path}")
+            logging.debug(f"No robusta config in {config_file_path}")
             return None
 
         logging.info(f"loading config {config_file_path}")

--- a/holmes/plugins/toolsets/investigator/core_investigation.py
+++ b/holmes/plugins/toolsets/investigator/core_investigation.py
@@ -1,16 +1,16 @@
 import logging
 import os
 from typing import Any, Dict
-
 from uuid import uuid4
+
 from holmes.core.todo_tasks_formatter import format_tasks
 from holmes.core.tools import (
-    Toolset,
-    ToolsetTag,
-    ToolParameter,
-    Tool,
     StructuredToolResult,
     StructuredToolResultStatus,
+    Tool,
+    ToolParameter,
+    Toolset,
+    ToolsetTag,
 )
 from holmes.plugins.toolsets.investigator.model import Task, TaskStatus
 
@@ -133,7 +133,6 @@ class CoreInvestigationToolset(Toolset):
             tags=[ToolsetTag.CORE],
             is_default=True,
         )
-        logging.info("Core investigation toolset loaded")
 
     def get_example_config(self) -> Dict[str, Any]:
         return {}


### PR DESCRIPTION
Make config.dal to optional since dal is passing down to tool_executor and to the tool. This protect the case when we don't use Dal is CLI.