### PR TITLE
fix alignment issue in docs banner

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,7 +1,7 @@
 .md-banner {
   background: #000;
   color: white;
-  text-align: left;
+  text-align: center;
   font-size: 0.8rem;
   padding: 0.25rem 1rem;
   position: relative;
@@ -12,6 +12,7 @@
 .md-banner__inner {
   max-width: 1200px;
   margin: 0 auto;
+  text-align: center;
 }
 
 .md-banner a {


### PR DESCRIPTION
<img width="1915" height="1016" alt="Screenshot 2025-09-29 at 14 43 00" src="https://github.com/user-attachments/assets/e9db630f-ac98-4f8f-822a-8dcdcca89a5b" />
<img width="1915" height="1016" alt="Screenshot 2025-09-29 at 14 42 54" src="https://github.com/user-attachments/assets/8eab2a76-68f9-406f-9134-99d686a82dc4" />
